### PR TITLE
paymentVoucher: handle advance invoice

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/InvoiceServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/InvoiceServiceImpl.java
@@ -472,6 +472,13 @@ public class InvoiceServiceImpl extends InvoiceRepository implements InvoiceServ
     }
   }
 
+  /**
+   * Indicates if the provided advance payment is suitable to be bound to the given invoice.
+   * @param invoice Invoice to which the advance payment could be bound.
+   * @param candidateAdvancePayment Advance payment to check
+   * @return true if the candidate total amount is less or equals to the invoice's total amount
+   * @throws AxelorException
+   */
   protected boolean removeBecauseOfTotalAmount(Invoice invoice, Invoice candidateAdvancePayment)
       throws AxelorException {
     if (Beans.get(AccountConfigService.class)
@@ -492,6 +499,7 @@ public class InvoiceServiceImpl extends InvoiceRepository implements InvoiceServ
             .orElse(BigDecimal.ZERO);
     return totalAmount.compareTo(invoiceTotal) > 0;
   }
+
 
   protected boolean removeBecauseOfAmountRemaining(Invoice invoice, Invoice candidateAdvancePayment)
       throws AxelorException {

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/payment/paymentvoucher/PaymentVoucherToolService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/payment/paymentvoucher/PaymentVoucherToolService.java
@@ -37,17 +37,13 @@ public class PaymentVoucherToolService {
     boolean isDebitToPay;
 
     switch (paymentVoucher.getOperationTypeSelect()) {
-      case PaymentVoucherRepository.OPERATION_TYPE_SUPPLIER_PURCHASE:
-        isDebitToPay = false;
-        break;
-      case PaymentVoucherRepository.OPERATION_TYPE_SUPPLIER_REFUND:
-        isDebitToPay = true;
-        break;
-      case PaymentVoucherRepository.OPERATION_TYPE_CLIENT_SALE:
-        isDebitToPay = true;
-        break;
+      case PaymentVoucherRepository.OPERATION_TYPE_SUPPLIER_PURCHASE: // fall-through
       case PaymentVoucherRepository.OPERATION_TYPE_CLIENT_REFUND:
         isDebitToPay = false;
+        break;
+      case PaymentVoucherRepository.OPERATION_TYPE_SUPPLIER_REFUND: // fall-through
+      case PaymentVoucherRepository.OPERATION_TYPE_CLIENT_SALE:
+        isDebitToPay = true;
         break;
 
       default:

--- a/axelor-account/src/main/resources/domains/PayVoucherDueElement.xml
+++ b/axelor-account/src/main/resources/domains/PayVoucherDueElement.xml
@@ -1,21 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<domain-models xmlns="http://axelor.com/xml/ns/domain-models"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://axelor.com/xml/ns/domain-models http://axelor.com/xml/ns/domain-models/domain-models_5.0.xsd">
+<domain-models xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns="http://axelor.com/xml/ns/domain-models"
+               xsi:schemaLocation="http://axelor.com/xml/ns/domain-models http://axelor.com/xml/ns/domain-models/domain-models_5.0.xsd">
 
-  <module name="account" package="com.axelor.apps.account.db"/>
+    <module name="account" package="com.axelor.apps.account.db"/>
 
-  <entity name="PayVoucherDueElement" sequential="true" lang="java">
-  
-  	<many-to-one name="paymentVoucher" ref="com.axelor.apps.account.db.PaymentVoucher" title="Payment" readonly="true"/>
-  
-    <many-to-one name="moveLine" ref="com.axelor.apps.account.db.MoveLine" title="Move Line" readonly="true"/>
-	<decimal name="dueAmount" title="Due amount" readonly="true"/>
-	<decimal name="paidAmount" title="Amount already paid" readonly="true"/>
-	<decimal name="amountRemaining" title="Amount remaining" readonly="true"/>
-  	
-  	<many-to-one name="currency" ref="com.axelor.apps.base.db.Currency" title="Currency"/>
-  	
-  </entity>
-  
+    <!-- Represents an element that may be imputed on a PaymentVoucher, when imputed on the PaymentVoucher, it becames a PayVoucherElementToPay -->
+    <entity name="PayVoucherDueElement" sequential="true" lang="java">
+
+        <many-to-one name="paymentVoucher" ref="com.axelor.apps.account.db.PaymentVoucher" title="Payment" readonly="true"/>
+
+        <!-- Advance payment invoices do not generate move, so we've to reference them directly -->
+        <many-to-one name="moveLine" ref="com.axelor.apps.account.db.MoveLine" title="Move Line" readonly="true"/>
+        <many-to-one name="advanceInvoice" ref="com.axelor.apps.account.db.Invoice" title="Advance invoice" readonly="true"/>
+
+        <decimal name="dueAmount" title="Due amount" readonly="true"/>
+        <decimal name="paidAmount" title="Amount already paid" readonly="true"/>
+        <decimal name="amountRemaining" title="Amount remaining" readonly="true"/>
+
+        <many-to-one name="currency" ref="com.axelor.apps.base.db.Currency" title="Currency"/>
+
+        <many-to-one name="invoice" ref="com.axelor.apps.account.db.Invoice" title="Invoice" readonly="true">
+            <![CDATA[
+            if(advanceInvoice != null) {
+                return advanceInvoice;
+            } else {
+                return moveLine.getMove().getInvoice();
+            }
+            ]]>
+        </many-to-one>
+        <date name="dueDate" readonly="true">
+            <![CDATA[
+            if(advanceInvoice != null) {
+                return advanceInvoice.getDueDate();
+            } else {
+                return moveLine.getDueDate();
+            }
+            ]]>
+        </date>
+    </entity>
+
 </domain-models>

--- a/axelor-account/src/main/resources/domains/PayVoucherElementToPay.xml
+++ b/axelor-account/src/main/resources/domains/PayVoucherElementToPay.xml
@@ -1,25 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<domain-models xmlns="http://axelor.com/xml/ns/domain-models"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://axelor.com/xml/ns/domain-models http://axelor.com/xml/ns/domain-models/domain-models_5.0.xsd">
+<domain-models xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns="http://axelor.com/xml/ns/domain-models"
+               xsi:schemaLocation="http://axelor.com/xml/ns/domain-models http://axelor.com/xml/ns/domain-models/domain-models_5.0.xsd">
 
-  <module name="account" package="com.axelor.apps.account.db"/>
+    <module name="account" package="com.axelor.apps.account.db"/>
 
-  <entity name="PayVoucherElementToPay" sequential="true" lang="java">
-	
-	<integer name="sequence" title="Seq." />
-	<many-to-one name="moveLine" ref="com.axelor.apps.account.db.MoveLine" title="Move line" readonly="true"/>
-	<decimal name="totalAmount" title="Total amount" readonly="true"/>
-	<decimal name="remainingAmount" title="Amount remaining before cashing" readonly="true"/>
-	
-	<many-to-one name="moveLineGenerated" ref="com.axelor.apps.account.db.MoveLine" title="Move Line generated" readonly="true"/>
-	<many-to-one name="paymentVoucher" ref="com.axelor.apps.account.db.PaymentVoucher" title="Payment" readonly="true"/>
-	<many-to-one name="currency" ref="com.axelor.apps.base.db.Currency" title="Currency"/>
-	<decimal name="amountToPayCurrency" title="Imput. amount in currency"/>
-	<decimal name="amountToPay" title="Imput amount"/>
+    <entity name="PayVoucherElementToPay" sequential="true" lang="java">
 
-	<decimal name="remainingAmountAfterPayment" title="Remaining to pay after cashing" readonly="true"/>
+        <integer name="sequence" title="Seq."/>
+        <many-to-one name="moveLine" ref="com.axelor.apps.account.db.MoveLine" title="Move line" readonly="true"/>
+        <many-to-one name="advanceInvoice" ref="com.axelor.apps.account.db.Invoice" title="Invoice" readonly="true"/>
+        <decimal name="totalAmount" title="Total amount" readonly="true"/>
+        <decimal name="remainingAmount" title="Amount remaining before cashing" readonly="true"/>
 
-  </entity>
+        <many-to-one name="moveLineGenerated" ref="com.axelor.apps.account.db.MoveLine" title="Move Line generated" readonly="true"/>
+        <many-to-one name="paymentVoucher" ref="com.axelor.apps.account.db.PaymentVoucher" title="Payment" readonly="true"/>
+        <many-to-one name="currency" ref="com.axelor.apps.base.db.Currency" title="Currency"/>
+        <decimal name="amountToPayCurrency" title="Imput. amount in currency"/>
+        <decimal name="amountToPay" title="Imput amount"/>
+
+        <decimal name="remainingAmountAfterPayment" title="Remaining to pay after cashing" readonly="true"/>
+
+        <many-to-one name="invoice" ref="com.axelor.apps.account.db.Invoice" title="Invoice" readonly="true">
+            <![CDATA[
+            if(advanceInvoice != null) {
+                return advanceInvoice;
+            } else {
+                return moveLine.getMove().getInvoice();
+            }
+            ]]>
+        </many-to-one>
+        <date name="dueDate" readonly="true">
+            <![CDATA[
+            if(advanceInvoice != null) {
+                return advanceInvoice.getDueDate();
+            } else {
+                return moveLine.getDueDate();
+            }
+            ]]>
+        </date>
+
+    </entity>
 
 </domain-models>

--- a/axelor-account/src/main/resources/views/PayVoucherDueElement.xml
+++ b/axelor-account/src/main/resources/views/PayVoucherDueElement.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<object-views xmlns="http://axelor.com/xml/ns/object-views"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://axelor.com/xml/ns/object-views http://axelor.com/xml/ns/object-views/object-views_5.0.xsd">
+<object-views xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="http://axelor.com/xml/ns/object-views"
+              xsi:schemaLocation="http://axelor.com/xml/ns/object-views http://axelor.com/xml/ns/object-views/object-views_5.0.xsd">
     <grid name="pay-voucher-due-element-grid" title="Invoices to pay" model="com.axelor.apps.account.db.PayVoucherDueElement" orderBy="moveLine.dueDate">
-        <field name="moveLine.dueDate"/>
+        <field name="dueDate"/>
+        <field name="invoice" form-view="invoice-form" grid-view="invoice-grid"/>
         <field name="moveLine" form-view="move-line-form" grid-view="move-line-grid"/>
-        <field name="moveLine.move.invoice"/>
         <field name="currency" form-view="currency-form" grid-view="currency-grid"/>
         <field name="dueAmount" aggregate="sum"/>
         <field name="paidAmount" aggregate="sum"/>
         <field name="amountRemaining" aggregate="sum"/>
     </grid>
-    <form name="pay-voucher-due-element-form" title="Invoices to pay" model="com.axelor.apps.account.db.PayVoucherDueElement"  >
-        <panel name="main" >
-        	<field name="moveLine" form-view="move-line-form" grid-view="move-line-grid"/>
-	        <field name="moveLine.move.invoice" grid-view="invoice-grid" form-view="invoice-form"/>
-	        <field name="moveLine.dueDate"/>
-	        <field name="currency" canEdit="false" form-view="currency-form" grid-view="currency-grid"/>
-	        <field name="dueAmount"/>
-	        <field name="paidAmount"/>
-	        <field name="amountRemaining"/>
+    <form name="pay-voucher-due-element-form" title="Invoices to pay" model="com.axelor.apps.account.db.PayVoucherDueElement">
+        <panel name="main">
+            <field name="moveLine" form-view="move-line-form" grid-view="move-line-grid" hideIf="moveLine == null"/>
+            <field name="invoice" grid-view="invoice-grid" form-view="invoice-form" hideIf="invoice == null"/>
+            <field name="dueDate"/>
+            <field name="currency" canEdit="false" form-view="currency-form" grid-view="currency-grid"/>
+            <field name="dueAmount"/>
+            <field name="paidAmount"/>
+            <field name="amountRemaining"/>
         </panel>
     </form>
 </object-views>

--- a/axelor-account/src/main/resources/views/PayVoucherElementToPay.xml
+++ b/axelor-account/src/main/resources/views/PayVoucherElementToPay.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<object-views xmlns="http://axelor.com/xml/ns/object-views"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://axelor.com/xml/ns/object-views http://axelor.com/xml/ns/object-views/object-views_5.0.xsd">
+<object-views xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="http://axelor.com/xml/ns/object-views"
+              xsi:schemaLocation="http://axelor.com/xml/ns/object-views http://axelor.com/xml/ns/object-views/object-views_5.0.xsd">
     <grid name="pay-voucher-element-to-pay-grid" title="Payment voucher invoices to pay" model="com.axelor.apps.account.db.PayVoucherElementToPay">
         <field name="sequence"/>
-        <field name="moveLine.move.invoice" grid-view="invoice-grid" form-view="invoice-form"/>
+        <field name="invoice" form-view="invoice-form" grid-view="invoice-grid"/>
         <field name="moveLine" form-view="move-line-form" grid-view="move-line-grid"/>
         <field name="currency" form-view="currency-form" grid-view="currency-grid"/>
         <field name="totalAmount" aggregate="sum"/>
         <field name="remainingAmount" aggregate="sum"/>
         <field name="remainingAmountAfterPayment" aggregate="sum"/>
-        <field name="amountToPay" aggregate="sum"/>  
+        <field name="amountToPay" aggregate="sum"/>
     </grid>
-    <form name="pay-voucher-element-to-pay-form" title="Payment voucher invoices to pay" model="com.axelor.apps.account.db.PayVoucherElementToPay"  >
-        <panel name="main" >
-        	<field name="sequence"/>
-	        <field name="moveLine.move.invoice" grid-view="invoice-grid" form-view="invoice-form"/>
-	        <field name="moveLine" form-view="move-line-form" grid-view="move-line-grid"/>
-	        <field name="currency" canEdit="false" form-view="currency-form" grid-view="currency-grid"/>
-	        <field name="totalAmount"/>
-	        <field name="remainingAmount"/>
-	        <field name="remainingAmountAfterPayment"/>
-	        <field name="amountToPay" onChange="save, action-method-account-payment-voucher-element-pay-amount"/>
-	        <field name="moveLineGenerated" form-view="move-line-form" grid-view="move-line-grid"/>
+    <form name="pay-voucher-element-to-pay-form" title="Payment voucher invoices to pay" model="com.axelor.apps.account.db.PayVoucherElementToPay">
+        <panel name="main">
+            <field name="sequence"/>
+            <field name="moveLine" form-view="move-line-form" grid-view="move-line-grid" hideIf="moveLine == null"/>
+            <field name="invoice" grid-view="invoice-grid" form-view="invoice-form" hideIf="invoice == null"/>
+            <field name="currency" canEdit="false" form-view="currency-form" grid-view="currency-grid"/>
+            <field name="totalAmount"/>
+            <field name="remainingAmount"/>
+            <field name="remainingAmountAfterPayment"/>
+            <field name="amountToPay" onChange="save, action-method-account-payment-voucher-element-pay-amount"/>
+            <field name="moveLineGenerated" form-view="move-line-form" grid-view="move-line-grid"/>
         </panel>
-        
     </form>
 
     <action-method name="action-method-account-payment-voucher-element-pay-amount">


### PR DESCRIPTION
Allow PayementVoucherDueElement/ElementToPay to be bound directly to an
invoice since there is no moveLine for invoice payment (see issue #2075)
Correctly handle the null moveLine on the whole process up to payment
confirmation.
Right now there is no reconciliation when balance invoice is generated,
this should come soon
By the way, the whole payment process is kind of cryptic with
ReconcileService generating invoice payments…