### PR TITLE
Accounting: correctly use invoice date for currency conversion

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/generator/InvoiceLineGenerator.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/generator/InvoiceLineGenerator.java
@@ -317,16 +317,18 @@ public abstract class InvoiceLineGenerator extends InvoiceLineManagement {
           company.getName());
     }
 
+    LocalDate d = invoice.getInvoiceDate() == null ? today : invoice.getInvoiceDate();
+
     invoiceLine.setCompanyExTaxTotal(
         currencyService
             .getAmountCurrencyConvertedAtDate(
-                invoice.getCurrency(), companyCurrency, exTaxTotal, today)
+                invoice.getCurrency(), companyCurrency, exTaxTotal, d)
             .setScale(AppBaseService.DEFAULT_NB_DECIMAL_DIGITS, RoundingMode.HALF_UP));
 
     invoiceLine.setCompanyInTaxTotal(
         currencyService
             .getAmountCurrencyConvertedAtDate(
-                invoice.getCurrency(), companyCurrency, inTaxTotal, today)
+                invoice.getCurrency(), companyCurrency, inTaxTotal, d)
             .setScale(AppBaseService.DEFAULT_NB_DECIMAL_DIGITS, RoundingMode.HALF_UP));
   }
 


### PR DESCRIPTION
Invoices can be created long time after they've been emitted. General accounting rules states that we should use the invoice date to compute values in company currency, not today's date.

As usual; no changelog in commit to ease merge…
Accounting: use invoice date (if filled) to compute company in/ex tax total