### PR TITLE
[Anomaly #21675] TEAMTASKS : financial data - update

### DIFF
--- a/axelor-project/src/main/resources/views/TeamTask.xml
+++ b/axelor-project/src/main/resources/views/TeamTask.xml
@@ -503,12 +503,6 @@
 		<attribute name="value" for="toInvoice" expr="eval: false" if="invoicingType != 1"/>
 		<attribute name="value" for="isOrderProposed" expr="eval: true" if="invoicingType == 1"/>
 		<attribute name="value" for="isOrderProposed" expr="eval: false" if="invoicingType != 1"/>
-		<attribute name="value" for="product" expr="eval: null" if="invoicingType == 2"/>
-		<attribute name="value" for="quantity" expr="eval: null" if="invoicingType == 2"/>
-		<attribute name="value" for="unit" expr="eval: null" if="invoicingType == 2"/>
-		<attribute name="value" for="unitPrice" expr="eval: null" if="invoicingType == 2"/>
-		<attribute name="value" for="currency" expr="eval: null" if="invoicingType == 2"/>
-		<attribute name="value" for="exTaxTotal" expr="eval: null" if="invoicingType == 2"/>
 	</action-attrs>
 	
 	<action-attrs name="action-team-task-attrs-assginment-customer">


### PR DESCRIPTION
product, quantity, unit, unitPrice, currency and exTaxTotal fields should not be reset on change of invoicingType