### PR TITLE
Find user by email using partner email address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Manuf Order: fix real quantity not updating when a new line in consumed products is created.
 - INVOICE PAYMENT CANCELLATION : corrected error when boolean allow removal validate move in account configuration is true.
 - INVOICE : stopped the creation of invoice payment when a reconciliation is made with accounts not used in partner balance.
+- User: find user by email using partner email address
 
 ## [5.2.0] - 2019-11-29
 ## Features

--- a/axelor-base/src/main/java/com/axelor/apps/base/db/repo/UserBaseRepository.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/db/repo/UserBaseRepository.java
@@ -22,6 +22,7 @@ import com.axelor.apps.base.service.user.UserService;
 import com.axelor.auth.db.User;
 import com.axelor.auth.db.repo.UserRepository;
 import com.axelor.common.StringUtils;
+import com.axelor.db.Query;
 import com.axelor.inject.Beans;
 import javax.persistence.PersistenceException;
 
@@ -81,5 +82,30 @@ public class UserBaseRepository extends UserRepository {
       }
     }
     super.remove(user);
+  }
+
+  @Override
+  public User findByEmail(String email) {
+    return Query.of(User.class)
+        .filter(
+            ""
+                + "LOWER(self.partner.emailAddress.address) = LOWER(:email) "
+                + "OR LOWER(self.email) = LOWER(:email)")
+        .bind("email", email)
+        .cacheable()
+        .fetchOne();
+  }
+
+  @Override
+  public User findByCodeOrEmail(String codeOrEmail) {
+    return Query.of(User.class)
+        .filter(
+            ""
+                + "LOWER(self.code) = LOWER(:codeOrEmail) "
+                + "OR LOWER(self.partner.emailAddress.address) = LOWER(:codeOrEmail) "
+                + "OR LOWER(self.email) = LOWER(:codeOrEmail)")
+        .bind("codeOrEmail", codeOrEmail)
+        .cacheable()
+        .fetchOne();
   }
 }


### PR DESCRIPTION
AOS doesn't use user email field, so finder methods in user repository
need to be overridden.

This is needed when finding user by email address via single sign-on.

Addresses RM-19444