### PR TITLE
RM#23948: cherry-pick from 5.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@
 - PRODUCT - added tracking on code and name fields.
 
 ## Improvements
+
 ## Bug Fixes
 - Ebics User : resolve error getting on export & Modify import config and export template to include BankOrderList and BankStatementList of EbicsPartner
 - BankOrder : Fix NPE on click of confirm for International transfer.
 - BATCH : set batchList empty on copy for BankPaymentBatch and ContractBatch.
 - Invoice Payment : resolve invoice amount due update when the generate accounting move option is not active
+- BANK ORDER : corrected the possibility to generate two times the same move.
+- BANK ORDER : corrected the behavior of bank order, now the bank order moves can be generated on validation or realization.
 
 ## [5.2.1] - 2019-12-16
 ## Features

--- a/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/service/bankorder/BankOrderMoveServiceImpl.java
+++ b/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/service/bankorder/BankOrderMoveServiceImpl.java
@@ -36,6 +36,7 @@ import com.axelor.apps.base.db.BankDetails;
 import com.axelor.apps.base.db.Company;
 import com.axelor.apps.base.db.Currency;
 import com.axelor.apps.base.db.Partner;
+import com.axelor.common.ObjectUtils;
 import com.axelor.exception.AxelorException;
 import com.axelor.exception.db.repo.TraceBackRepository;
 import com.axelor.i18n.I18n;
@@ -112,16 +113,19 @@ public class BankOrderMoveServiceImpl implements BankOrderMoveService {
     }
 
     for (BankOrderLine bankOrderLine : bankOrder.getBankOrderLineList()) {
-
-      generateMoves(bankOrderLine);
+      if (ObjectUtils.isEmpty(bankOrderLine.getBankOrderLineOriginList())) {
+        generateMoves(bankOrderLine);
+      }
     }
   }
 
   protected void generateMoves(BankOrderLine bankOrderLine) throws AxelorException {
 
-    bankOrderLine.setSenderMove(generateSenderMove(bankOrderLine));
-
-    if (partnerTypeSelect == BankOrderRepository.PARTNER_TYPE_COMPANY) {
+    if (bankOrderLine.getSenderMove() == null) {
+      bankOrderLine.setSenderMove(generateSenderMove(bankOrderLine));
+    }
+    if (partnerTypeSelect == BankOrderRepository.PARTNER_TYPE_COMPANY
+        && bankOrderLine.getReceiverMove() == null) {
       bankOrderLine.setReceiverMove(generateReceiverMove(bankOrderLine));
     }
   }

--- a/axelor-human-resource/src/main/java/com/axelor/apps/hr/service/bankorder/BankOrderServiceHRImpl.java
+++ b/axelor-human-resource/src/main/java/com/axelor/apps/hr/service/bankorder/BankOrderServiceHRImpl.java
@@ -24,6 +24,7 @@ import com.axelor.apps.bankpayment.db.repo.BankOrderRepository;
 import com.axelor.apps.bankpayment.ebics.service.EbicsService;
 import com.axelor.apps.bankpayment.service.bankorder.BankOrderLineOriginService;
 import com.axelor.apps.bankpayment.service.bankorder.BankOrderLineService;
+import com.axelor.apps.bankpayment.service.bankorder.BankOrderMoveService;
 import com.axelor.apps.bankpayment.service.bankorder.BankOrderServiceImpl;
 import com.axelor.apps.bankpayment.service.config.BankPaymentConfigService;
 import com.axelor.apps.base.service.administration.SequenceService;
@@ -50,7 +51,8 @@ public class BankOrderServiceHRImpl extends BankOrderServiceImpl {
       BankPaymentConfigService bankPaymentConfigService,
       SequenceService sequenceService,
       BankOrderLineOriginService bankOrderLineOriginService,
-      ExpenseService expenseService) {
+      ExpenseService expenseService,
+      BankOrderMoveService bankOrderMoveService) {
     super(
         bankOrderRepo,
         invoicePaymentRepo,
@@ -59,7 +61,8 @@ public class BankOrderServiceHRImpl extends BankOrderServiceImpl {
         invoicePaymentCancelService,
         bankPaymentConfigService,
         sequenceService,
-        bankOrderLineOriginService);
+        bankOrderLineOriginService,
+        bankOrderMoveService);
     this.expenseService = expenseService;
   }
 


### PR DESCRIPTION
BANK ORDER : corrected the possibility to generate two times the same move and corrected the behavior of bank order, now the bank order moves can be generated on validation or realization.