### PR TITLE
RM#25166: MOVE : corrected sequence generation, now use correctly the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Configurator: Fix sale order line not being created from a configurator.
 - Configurator: Generate bill of material on generating a sale order line from a configurator.
 - SaleOrderLine : Hide qty cell in SaleOrder report when saleOrderLine contain typeSelect equal to 'title'.
+- MOVE : corrected sequence generation, now use correctly the date of the move and not the date of validation.
 
 ## [5.2.3] - 2020-01-23
 ## Features

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveSequenceService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveSequenceService.java
@@ -57,6 +57,6 @@ public class MoveSequenceService {
           I18n.get(IExceptionMessage.MOVE_5),
           journal.getName());
     }
-    move.setReference(sequenceService.getSequenceNumber(journal.getSequence()));
+    move.setReference(sequenceService.getSequenceNumber(journal.getSequence(), move.getDate()));
   }
 }


### PR DESCRIPTION
… date of the move and not the date of validation.