### PR TITLE
RM#25166: MOVE : corrected sequence generation, now use correctly the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - MOVE LINE : removed the possibility to delete a move line in a move when the move line is reconcile.
 - FIXED ASSET : correction of prorata temporis
 - INVOICE : now the date verification of the ventilation process depends of invoices of the same company.
+- MOVE : corrected sequence generation, now use correctly the date of the move and not the date of validation.
 
 ## [5.1.14] - 2020-01-17
 ## Improvements
@@ -89,6 +90,7 @@
 - PRICE LIST: get lower price for same qty for same product.
 
 ## Bug Fixes
+<<<<<<< HEAD
 - STOCK : Changed type select french translation
 - ACCOUNTING: generate taxlines translation.
 - AnalyticMoveLine: fix amount calculation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,6 @@
 - PRICE LIST: get lower price for same qty for same product.
 
 ## Bug Fixes
-<<<<<<< HEAD
 - STOCK : Changed type select french translation
 - ACCOUNTING: generate taxlines translation.
 - AnalyticMoveLine: fix amount calculation.

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveSequenceService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveSequenceService.java
@@ -57,6 +57,6 @@ public class MoveSequenceService {
           I18n.get(IExceptionMessage.MOVE_5),
           journal.getName());
     }
-    move.setReference(sequenceService.getSequenceNumber(journal.getSequence()));
+    move.setReference(sequenceService.getSequenceNumber(journal.getSequence(), move.getDate()));
   }
 }


### PR DESCRIPTION
… date of the move and not the date of validation.