### PR TITLE
RM#25166: MOVE : corrected sequence generation, now use correctly the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - EBICS USER : fix for strange import - log
 - LEAVE REQUEST: Updated calendar filter
 - STOCK MOVE : Fix link between sale order and backorder stockmove
+- MOVE : corrected sequence generation, now use correctly the date of the move and not the date of validation.
 
 ## [5.0.11] - 2019-12-19
 ## Improvements

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveSequenceService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveSequenceService.java
@@ -57,6 +57,6 @@ public class MoveSequenceService {
           I18n.get(IExceptionMessage.MOVE_5),
           journal.getName());
     }
-    move.setReference(sequenceService.getSequenceNumber(journal.getSequence()));
+    move.setReference(sequenceService.getSequenceNumber(journal.getSequence(), move.getDate()));
   }
 }


### PR DESCRIPTION
… date of the move and not the date of validation.