### PR TITLE
RM#25898 : Manuf. order bugfix. No longer diplay unavaible tracking numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - LEAVE REQUEST : Fix the NPE when no leaveRequest is selected to be edited
 - AccountChartService : BLOCKER - line 99
 - PROJECT : Remove unnecessary code.
+- MANUFACTURING ORDER : On consumed product, no longer diplay tracking numbers if avaible quantity equals 0.
 
 ## [5.2.5] - 2020-02-25
 ## Improvements

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineServiceImpl.java
@@ -1201,7 +1201,7 @@ public class StockMoveLineServiceImpl implements StockMoveLineService {
             + stockMoveLine.getProduct().getId()
             + " AND self.id in (select stockLocationLine.trackingNumber.id from StockLocationLine stockLocationLine join StockLocation sl on sl.id = stockLocationLine.detailsStockLocation.id WHERE sl.id = "
             + stockMove.getFromStockLocation().getId()
-            + " )";
+            + " AND coalesce(stockLocationLine.currentQty, 0) != 0)";
     trackingNumbers = trackingNumberRepo.all().filter(domain).fetch();
     return trackingNumbers;
   }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/web/StockMoveLineController.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/web/StockMoveLineController.java
@@ -262,10 +262,7 @@ public class StockMoveLineController {
       StockLocationLine detailStockLocationLine =
           stockLocationLineService.getDetailLocationLine(
               stockMove.getFromStockLocation(), stockMoveLine.getProduct(), trackingNumber);
-      BigDecimal availableQty =
-          detailStockLocationLine != null
-              ? detailStockLocationLine.getCurrentQty()
-              : BigDecimal.ZERO;
+      BigDecimal availableQty = detailStockLocationLine.getCurrentQty();
       Map<String, Object> map = new HashMap<String, Object>();
       map.put("trackingNumber", trackingNumber);
       map.put("trackingNumberSeq", trackingNumber.getTrackingNumberSeq());


### PR DESCRIPTION
On manuf-order-form > consumedProductsPanel > consumedStockMoveLineList > "split by tracking numbers" button
No longer displays tracknig numbers when avaibleQty equals 0

RM#25898