### PR TITLE
RM#25898 : Manuf. order bugfix. No longer diplay unavaible tracking numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@
 - Fix Timesheet Reminder Batch sendReminder method
 - Stock Move Line reservation: correctly set qty requested flag when generated from a sale order line.
 - Stock Move: Delete empty date field in form view.
+<<<<<<< HEAD
 - Advance data import: Fix search issue on main object to import.
 - LEAD : removed the persistable field on the form view
 - LEAVEREQUEST : Fix the NPE when no leaveRequest is selected to be edited
+- MANUFACTURING ORDER : On consumed product, no longer diplay tracking numbers if avaible quantity equals 0.
 
 ## [5.3.0] - 2020-02-25
 ## Features

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockMoveLineServiceImpl.java
@@ -1194,14 +1194,14 @@ public class StockMoveLineServiceImpl implements StockMoveLineService {
 
   public List<TrackingNumber> getAvailableTrackingNumbers(
       StockMoveLine stockMoveLine, StockMove stockMove) {
-    List<TrackingNumber> trackingNumbers = null;
     String domain =
         "self.product.id = "
             + stockMoveLine.getProduct().getId()
-            + " AND self.id in (select stockLocationLine.trackingNumber.id from StockLocationLine stockLocationLine join StockLocation sl on sl.id = stockLocationLine.detailsStockLocation.id WHERE sl.id = "
+            + " AND self.id in (select stockLocationLine.trackingNumber.id from StockLocationLine stockLocationLine"
+            + " join StockLocation sl on sl.id = stockLocationLine.detailsStockLocation.id WHERE sl.id = "
             + stockMove.getFromStockLocation().getId()
-            + " )";
-    trackingNumbers = trackingNumberRepo.all().filter(domain).fetch();
+            + " AND coalesce(stockLocationLine.currentQty, 0) != 0)";
+    List<TrackingNumber> trackingNumbers = trackingNumberRepo.all().filter(domain).fetch();
     return trackingNumbers;
   }
 

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/web/StockMoveLineController.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/web/StockMoveLineController.java
@@ -262,10 +262,7 @@ public class StockMoveLineController {
       StockLocationLine detailStockLocationLine =
           stockLocationLineService.getDetailLocationLine(
               stockMove.getFromStockLocation(), stockMoveLine.getProduct(), trackingNumber);
-      BigDecimal availableQty =
-          detailStockLocationLine != null
-              ? detailStockLocationLine.getCurrentQty()
-              : BigDecimal.ZERO;
+      BigDecimal availableQty = detailStockLocationLine.getCurrentQty();
       Map<String, Object> map = new HashMap<String, Object>();
       map.put("trackingNumber", trackingNumber);
       map.put("trackingNumberSeq", trackingNumber.getTrackingNumberSeq());


### PR DESCRIPTION
On manuf-order-form > consumedProductsPanel > consumedStockMoveLineList > "split by tracking numbers" button
No longer displays tracknig numbers when avaibleQty equals 0

RM#25898 (cherry-pick from 5.2, pull request #5047)