### PR TITLE
RM#26253 : Mass invoicing : sort generated lines by stock move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - CUSTOMER INFORMATIONS : Indicate that Payment delay is in days
 - INVOICES DASHBOARD: Turnover is now calculated using both sales and assets
 - PRODUCT : Quantity field digits length is now based on nbDecimalDigitForQty in Base Config
+- MASS INVOICING : When generating one invoice from two or more stock moves, invoices lines are sorted by strock move.
 
 ## Bug Fixes
 - Fix Timesheet Reminder Batch sendReminder method

--- a/axelor-account/src/main/resources/views/Invoice.xml
+++ b/axelor-account/src/main/resources/views/Invoice.xml
@@ -311,7 +311,7 @@
 
 		<panel-tabs name="mainPanelTab" hideIf="partner == null">
 			<panel name="invoiceContentPanel" title="Content" showTitle="false">
-				<panel-related name="invoiceLineListPanel" field="invoiceLineList" canNew="statusSelect == 1" canRemove="statusSelect == 1" readonlyIf="statusSelect == 3 || partner == null" colSpan="12" form-view="invoice-line-form" grid-view="invoice-line-grid" onChange="action-invoice-method-compute" canMove="true" orderBy="sequence"  height="30" />
+				<panel-related name="invoiceLineListPanel" field="invoiceLineList" canNew="statusSelect == 1" canRemove="statusSelect == 1" readonlyIf="statusSelect == 3 || partner == null" colSpan="12" form-view="invoice-line-form" grid-view="invoice-line-grid" onChange="action-invoice-method-compute" canMove="true" orderBy="id"  height="30" />
 			</panel>
 			<panel name="invoiceTaxPanel" title="Tax" showTitle="false">
 				<panel-related name="invoiceLineTaxListPanel" field="invoiceLineTaxList" colSpan="12" form-view="invoice-line-tax-form" grid-view="invoice-line-tax-grid"/>


### PR DESCRIPTION
Because the invoices lines are generated sequentialy, orderBy field is now on ID on invoiceLineList

RM#26253