### PR TITLE
RM#26253 : Mass invoicing, sort generated lines by stock move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - BANK ORDER: Bank order workflow pass from draft to validated when automatic transmission is not activated in payment mode.
 - INVOICE: add specific note of company bank details on invoice report.
 - SUPPLYCHAIN : In stock-detail-by-product menu, company field now autofill with the user's active company.
+- MASS INVOICING : When generating one invoice from two or more stock moves, invoices lines are sorted by strock move.
 
 ## Bug Fixes
 - Studio: Fix access to json fields of base model in chart builder form.

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveInvoiceService.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveInvoiceService.java
@@ -57,6 +57,10 @@ public interface StockMoveInvoiceService {
       Invoice invoice, List<StockMoveLine> stockMoveLineList, Map<Long, BigDecimal> qtyToInvoiceMap)
       throws AxelorException;
 
+  public List<InvoiceLine> createInvoiceLines(
+	      Invoice invoice, List<StockMoveLine> stockMoveLineList, Map<Long, BigDecimal> qtyToInvoiceMap, int lineSequence)
+	      throws AxelorException;
+  
   public List<InvoiceLine> createInvoiceLine(
       Invoice invoice, StockMoveLine stockMoveLine, BigDecimal qty) throws AxelorException;
 

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveMultiInvoiceServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveMultiInvoiceServiceImpl.java
@@ -376,14 +376,17 @@ public class StockMoveMultiInvoiceServiceImpl implements StockMoveMultiInvoiceSe
 
     List<InvoiceLine> invoiceLineList = new ArrayList<>();
 
+    int lineSeqenceFromStockMove = 0;
+    
     for (StockMove stockMoveLocal : stockMoveList) {
       List<InvoiceLine> createdInvoiceLines =
           stockMoveInvoiceService.createInvoiceLines(
-              invoice, stockMoveLocal.getStockMoveLineList(), null);
+              invoice, stockMoveLocal.getStockMoveLineList(), null, lineSeqenceFromStockMove);
       if (stockMoveLocal.getTypeSelect() == StockMoveRepository.TYPE_INCOMING) {
         createdInvoiceLines.forEach(this::negateInvoiceLinePrice);
       }
       invoiceLineList.addAll(createdInvoiceLines);
+      lineSeqenceFromStockMove ++;
     }
 
     invoiceGenerator.populate(invoice, invoiceLineList);
@@ -465,14 +468,17 @@ public class StockMoveMultiInvoiceServiceImpl implements StockMoveMultiInvoiceSe
 
     List<InvoiceLine> invoiceLineList = new ArrayList<>();
 
+    int lineSeqenceFromStockMove = 0;
+    
     for (StockMove stockMoveLocal : stockMoveList) {
       List<InvoiceLine> createdInvoiceLines =
           stockMoveInvoiceService.createInvoiceLines(
-              invoice, stockMoveLocal.getStockMoveLineList(), null);
+              invoice, stockMoveLocal.getStockMoveLineList(), null, lineSeqenceFromStockMove);
       if (stockMoveLocal.getTypeSelect() == StockMoveRepository.TYPE_OUTGOING) {
         createdInvoiceLines.forEach(this::negateInvoiceLinePrice);
       }
       invoiceLineList.addAll(createdInvoiceLines);
+      lineSeqenceFromStockMove ++;
     }
 
     invoiceGenerator.populate(invoice, invoiceLineList);


### PR DESCRIPTION
On StockMoveInvoiceService added a variant of createInvoiceLines() method which take an additional int argument : "lineSequence" to create the invoiceLines with personalized sequences.
On StockMoveMultoInvoiceLineService(Impl) changed createInvoiceFromMultiOutgoingStockMove() & createInvoiceFromMultiIncomingStockMove() to call the new variant of createInvoiceLines() with custom sequences.

RM#26253