### PR TITLE
Sale Order Invoicing: rework the wizard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
 - INVOICELINE : Fix account not filtered depending on fixedAssets boolean
 - CONTACT: fix for Main Company not set for Contact from Partner
 - Account Config: display correct form view on clicking products.
+- Sale Order Invoicing: rework the wizard.
+Now the sale order invoicing pop-up correctly takes into account refund and correctly ignores advance payment.
+Also we correctly manage the already invoiced quantity when invoicing by line.
 
 ## [5.3.1] - 2020-03-16
 ## Improvements

--- a/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/SaleOrderInvoiceProjectServiceImpl.java
+++ b/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/SaleOrderInvoiceProjectServiceImpl.java
@@ -33,10 +33,10 @@ import com.axelor.apps.project.db.Project;
 import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.sale.db.SaleOrderLine;
 import com.axelor.apps.sale.db.repo.SaleOrderRepository;
-import com.axelor.apps.sale.service.saleorder.SaleOrderLineService;
 import com.axelor.apps.sale.service.saleorder.SaleOrderWorkflowServiceImpl;
 import com.axelor.apps.stock.db.repo.StockMoveRepository;
 import com.axelor.apps.supplychain.service.SaleOrderInvoiceServiceImpl;
+import com.axelor.apps.supplychain.service.SaleOrderLineServiceSupplyChain;
 import com.axelor.apps.supplychain.service.app.AppSupplychainService;
 import com.axelor.exception.AxelorException;
 import com.axelor.inject.Beans;
@@ -58,7 +58,7 @@ public class SaleOrderInvoiceProjectServiceImpl extends SaleOrderInvoiceServiceI
       InvoiceService invoiceService,
       AppBusinessProjectService appBusinessProjectService,
       StockMoveRepository stockMoveRepository,
-      SaleOrderLineService saleOrderLineService,
+      SaleOrderLineServiceSupplyChain saleOrderLineSupplychainService,
       SaleOrderWorkflowServiceImpl saleOrderWorkflowServiceImpl) {
     super(
         appBaseService,
@@ -66,7 +66,7 @@ public class SaleOrderInvoiceProjectServiceImpl extends SaleOrderInvoiceServiceI
         saleOrderRepo,
         invoiceRepo,
         invoiceService,
-        saleOrderLineService,
+        saleOrderLineSupplychainService,
         stockMoveRepository,
         saleOrderWorkflowServiceImpl);
     this.appBusinessProjectService = appBusinessProjectService;

--- a/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/SaleOrderLineProjectServiceImpl.java
+++ b/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/SaleOrderLineProjectServiceImpl.java
@@ -18,9 +18,17 @@
 package com.axelor.apps.businessproject.service;
 
 import com.axelor.apps.account.db.AnalyticMoveLine;
+import com.axelor.apps.account.db.repo.InvoiceLineRepository;
+import com.axelor.apps.account.service.AnalyticMoveLineService;
+import com.axelor.apps.account.service.app.AppAccountService;
+import com.axelor.apps.base.service.CurrencyService;
+import com.axelor.apps.base.service.PriceListService;
+import com.axelor.apps.base.service.ProductMultipleQtyService;
+import com.axelor.apps.base.service.tax.AccountManagementService;
 import com.axelor.apps.project.db.Project;
 import com.axelor.apps.sale.db.SaleOrderLine;
 import com.axelor.apps.sale.db.repo.SaleOrderLineRepository;
+import com.axelor.apps.sale.service.app.AppSaleService;
 import com.axelor.apps.supplychain.service.SaleOrderLineServiceSupplyChainImpl;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
@@ -29,7 +37,30 @@ import java.util.List;
 public class SaleOrderLineProjectServiceImpl extends SaleOrderLineServiceSupplyChainImpl
     implements SaleOrderLineProjectService {
 
-  @Inject private SaleOrderLineRepository saleOrderLineRepo;
+  private SaleOrderLineRepository saleOrderLineRepo;
+
+  @Inject
+  public SaleOrderLineProjectServiceImpl(
+      CurrencyService currencyService,
+      PriceListService priceListService,
+      ProductMultipleQtyService productMultipleQtyService,
+      AppSaleService appSaleService,
+      AccountManagementService accountManagementService,
+      AppAccountService appAccountService,
+      AnalyticMoveLineService analyticMoveLineService,
+      InvoiceLineRepository invoiceLineRepository,
+      SaleOrderLineRepository saleOrderLineRepo) {
+    super(
+        currencyService,
+        priceListService,
+        productMultipleQtyService,
+        appSaleService,
+        accountManagementService,
+        appAccountService,
+        analyticMoveLineService,
+        invoiceLineRepository);
+    this.saleOrderLineRepo = saleOrderLineRepo;
+  }
 
   @Transactional
   @Override

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/service/saleorder/SaleOrderLineServiceImpl.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/service/saleorder/SaleOrderLineServiceImpl.java
@@ -29,7 +29,6 @@ import com.axelor.apps.base.db.repo.PriceListLineRepository;
 import com.axelor.apps.base.service.CurrencyService;
 import com.axelor.apps.base.service.PriceListService;
 import com.axelor.apps.base.service.ProductMultipleQtyService;
-import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.tax.AccountManagementService;
 import com.axelor.apps.base.service.tax.FiscalPositionService;
 import com.axelor.apps.sale.db.PackLine;
@@ -55,17 +54,29 @@ public class SaleOrderLineServiceImpl implements SaleOrderLineService {
 
   private final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  @Inject protected CurrencyService currencyService;
+  protected CurrencyService currencyService;
 
-  @Inject protected PriceListService priceListService;
+  protected PriceListService priceListService;
 
-  @Inject protected ProductMultipleQtyService productMultipleQtyService;
+  protected ProductMultipleQtyService productMultipleQtyService;
 
-  @Inject protected AppBaseService appBaseService;
+  protected AppSaleService appSaleService;
 
-  @Inject protected AppSaleService appSaleService;
+  protected AccountManagementService accountManagementService;
 
-  @Inject protected AccountManagementService accountManagementService;
+  @Inject
+  public SaleOrderLineServiceImpl(
+      CurrencyService currencyService,
+      PriceListService priceListService,
+      ProductMultipleQtyService productMultipleQtyService,
+      AppSaleService appSaleService,
+      AccountManagementService accountManagementService) {
+    this.currencyService = currencyService;
+    this.priceListService = priceListService;
+    this.productMultipleQtyService = productMultipleQtyService;
+    this.appSaleService = appSaleService;
+    this.accountManagementService = accountManagementService;
+  }
 
   @Override
   public void computeProductInformation(SaleOrderLine saleOrderLine, SaleOrder saleOrder)
@@ -566,7 +577,7 @@ public class SaleOrderLineServiceImpl implements SaleOrderLineService {
             packLine
                 .getQuantity()
                 .multiply(packQty)
-                .setScale(appBaseService.getNbDecimalDigitForQty(), RoundingMode.HALF_EVEN));
+                .setScale(appSaleService.getNbDecimalDigitForQty(), RoundingMode.HALF_EVEN));
       }
       soLine.setUnit(packLine.getUnit());
       soLine.setTypeSelect(packLine.getTypeSelect());

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/SaleOrderInvoiceService.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/SaleOrderInvoiceService.java
@@ -38,6 +38,10 @@ import java.util.Map;
 
 public interface SaleOrderInvoiceService {
 
+  String SO_LINES_WIZARD_QTY_TO_INVOICE_FIELD = "qtyToInvoice";
+  String SO_LINES_WIZARD_QTY_REMAINING_TO_INVOICE_FIELD = "remainingQty";
+  String SO_LINES_WIZARD_SO_LINE_ID = "saleOrderLineId";
+
   /**
    * Generate an invoice from a sale order. call {@link
    * SaleOrderInvoiceService#createInvoice(SaleOrder)} to create the invoice.
@@ -273,25 +277,22 @@ public interface SaleOrderInvoiceService {
    * @param saleOrder the sale order from context
    * @return the domain for the operation select field in the invoicing wizard form
    */
-  List<Integer> getInvoicingWizardOperationDomain(SaleOrder saleOrder);
+  List<Integer> getInvoicingWizardOperationDomain(SaleOrder saleOrder) throws AxelorException;
 
   /**
-   * throw exception if all invoices amount generated from the sale order and amountToInvoice is
-   * greater than saleOrder's amount
+   * Compute sale order line to invoice to be shown in the invoicing wizard.
    *
-   * @param saleOrder
-   * @param amountToInvoice
-   * @param isPercent
-   * @throws AxelorException
+   * @param saleOrder a sale order
+   * @return a list of created sale order line to be shown in a wizard view.
    */
-  void displayErrorMessageIfSaleOrderIsInvoiceable(
-      SaleOrder saleOrder, BigDecimal amountToInvoice, boolean isPercent) throws AxelorException;
+  List<Map<String, Object>> getSaleOrderLinesToInvoice(SaleOrder saleOrder) throws AxelorException;
 
   /**
-   * Display error message if all invoices have been generated for the sale order
+   * Method used for the invoicing wizard. The computation uses the invoicing quantity, but also
+   * quantity from invoices that are not still ventilated. Also manage the case of refund invoice.
    *
-   * @param saleOrder
-   * @throws AxelorException
+   * @param saleOrder a sale order
+   * @return the quantity remaining to invoice for the sale order.
    */
-  void displayErrorMessageBtnGenerateInvoice(SaleOrder saleOrder) throws AxelorException;
+  BigDecimal computeTotalInvoicedQty(SaleOrder saleOrder) throws AxelorException;
 }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/SaleOrderLineServiceSupplyChain.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/SaleOrderLineServiceSupplyChain.java
@@ -19,6 +19,7 @@ package com.axelor.apps.supplychain.service;
 
 import com.axelor.apps.sale.db.SaleOrderLine;
 import com.axelor.apps.sale.service.saleorder.SaleOrderLineService;
+import com.axelor.exception.AxelorException;
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -70,4 +71,13 @@ public interface SaleOrderLineServiceSupplyChain extends SaleOrderLineService {
    * @param saleOrderLine
    */
   BigDecimal checkInvoicedOrDeliveredOrderQty(SaleOrderLine saleOrderLine);
+
+  /**
+   * Method used for the invoicing wizard. The computation uses the invoicing quantity, but also
+   * quantity from invoices that are not still ventilated. Also manage the case of refund invoice.
+   *
+   * @param saleOrderLine a sale order line with a sale order.
+   * @return the quantity remaining to invoice
+   */
+  BigDecimal computeInvoicedQty(SaleOrderLine saleOrderLine) throws AxelorException;
 }

--- a/axelor-supplychain/src/main/resources/views/SaleOrderInvoicingWizard.xml
+++ b/axelor-supplychain/src/main/resources/views/SaleOrderInvoicingWizard.xml
@@ -19,9 +19,21 @@
 			<field name="amountToInvoice" title="Amount to invoice" type="decimal" min="0"
 				   showIf="$contains([3],$number(operationSelect))"/>
 		</panel>
-		<panel-related name="saleOrderLineListPanel" field="saleOrderLineList" hideIf="operationSelect != 2" canNew="false"
-					   grid-view="invoicing-wizard-sale-order-line-grid"
-					   editable="true"/>
+		<panel-related name="saleOrderLineListPanel" field="$saleOrderLineDummyList" canNew="false" target="com.axelor.apps.sale.db.SaleOrderLine" type="one-to-many" editable="true" hideIf="operationSelect != 2">
+			<field name="$productCode" title="Code" width="120"/>
+			<field name="productName" readonly="true"/>
+			<field name="qty" readonly="true" aggregate="sum" x-scale="2"/>
+			<field name="unit" readonly="true" form-view="unit-form" grid-view="unit-grid"/>
+			<field name="price" readonly="true" x-scale="2"/>
+			<field name="exTaxTotal" readonly="true" aggregate="sum"/>
+			<field name="amountInvoiced" readonly="true"/>
+			<field name="remainingQty" readonly="true" aggregate="sum" title="Remaining Qty"/>
+			<field name="qtyToInvoice" title="Qty to invoice" type="decimal"
+				readonlyIf="invoiceAll || isSubline" min="0" validIf="$number(remainingQty) >= $number(qtyToInvoice)"/>
+			<field name="invoiceAll" title="Invoice all" type="boolean"
+				onChange="action-attrs-sale-order-line-invoicing-wizard-fill-qty"/>
+      <field name="saleOrderLineId" hidden="true"/>
+		</panel-related>
 		<panel name="timetablePanel" colSpan="12" showTitle="false" hidden="true" showIf="operationSelect == 4">
 			<field name="$uninvoicedTimetablesList" title="Select the lines to invoice" type="one-to-many" target="com.axelor.apps.supplychain.db.Timetable" 
 				   colSpan="12" canNew="false" canRemove="false" 
@@ -38,21 +50,6 @@
 		</panel>
 	</form>
 
-	<grid name="invoicing-wizard-sale-order-line-grid" title="Lines to invoice" edit-icon="false"
-		  model="com.axelor.apps.sale.db.SaleOrderLine">
-		<field name="product.code" width="120"/>
-		<field name="productName" readonly="true"/>
-		<field name="qty" readonly="true" aggregate="sum" x-scale="2"/>
-		<field name="unit" readonly="true" form-view="unit-form" grid-view="unit-grid"/>
-		<field name="price" readonly="true" x-scale="2"/>
-		<field name="exTaxTotal" readonly="true" aggregate="sum"/>
-		<field name="amountInvoiced" readonly="true"/>
-        <field name="qtyToInvoice" title="Qty to invoice" type="decimal"
-			   readonlyIf="invoiceAll" min="0" x-scale="2"/>
-        <field name="invoiceAll" title="Invoice all" type="boolean"
-			   onChange="action-attrs-sale-order-line-invoicing-wizard-fill-qty"/>
-	</grid>
-	
 	<grid name="invoicing-wizard-timetable-grid" title="Select timetables to invoice" edit-icon="false"
 		  model="com.axelor.apps.supplychain.db.Timetable" orderBy="estimatedDate" editable="true">
 		<field name="toInvoice" type="boolean" title=" "/>
@@ -73,8 +70,7 @@
 	</form>
 
 	<action-group name="action-group-sale-order-invoicing-wizard-onload">
-		<action name="action-method-sale-order-invoicing-wizard-default"/>
-		<action name="action-attrs-sale-order-invoicing-wizard-amount-invoiced"/>
+		<action name="action-method-sale-order-fill-invoicing-wizard"/>
 		<action name="action-attrs-sale-order-invoicing-wizard-hide-advance-payment"/>
 		<action name="action-method-sale-order-invoicing-wizard-operation-select-domain"/>
 		<action name="action-record-sale-order-invoicing-wizard-set-uninvoiced-timetables-list"/>
@@ -82,16 +78,11 @@
 	
 	<action-attrs name="action-attrs-sale-order-line-invoicing-wizard-fill-qty">
 		<attribute for="qtyToInvoice" name="value" if="invoiceAll &amp;&amp; !__parent__?.isPercent"
-				   expr="eval: qty"/>
+				   expr="eval: remainingQty"/>
 		<attribute for="qtyToInvoice" name="value" if="invoiceAll &amp;&amp; __parent__?.isPercent"
 				   expr="eval: 100"/>
 	</action-attrs>
 
-	<action-attrs name="action-attrs-sale-order-invoicing-wizard-amount-invoiced">
-		<attribute for="amountToInvoice" name="value" if="amountInvoiced > 0"
-				   expr="eval: exTaxTotal - amountInvoiced"/>
-	</action-attrs>
-	
 	<action-record name="action-record-sale-order-invoicing-wizard-set-uninvoiced-timetables-list" model="com.axelor.apps.sale.db.SaleOrder">
 		<field name="$uninvoicedTimetablesList" expr="eval: timetableList.findAll{it.invoiced == false}.sort{it.estimatedDate}"/>
 	</action-record>
@@ -106,9 +97,9 @@
 			  method="generateInvoice"/>
 	</action-method>
 
-	<action-method name="action-method-sale-order-invoicing-wizard-default">
+	<action-method name="action-method-sale-order-fill-invoicing-wizard">
 		<call class="com.axelor.apps.supplychain.web.SaleOrderController"
-			  method="fillDefaultValueWizard"/>
+			  method="fillInvoicingWizard"/>
 	</action-method>
   
       <action-group name="action-group-sale-order-invoicing-wizard-generate">


### PR DESCRIPTION
Now the sale order invoicing pop-up correctly takes into account refund
and correctly ignores advance payment. Also we correctly manage the
already invoiced quantity when invoicing by line.
Fixes RM24835