### PR TITLE
Refund: do not set ventilation info on generated refunds

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/generator/invoice/RefundInvoice.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/generator/invoice/RefundInvoice.java
@@ -52,7 +52,10 @@ public class RefundInvoice extends InvoiceGenerator implements InvoiceStrategy {
 
     Invoice refund = Beans.get(InvoiceRepository.class).copy(invoice, true);
 
+    // Not all properties should be copied
     refund.setOperationTypeSelect(this.inverseOperationType(refund.getOperationTypeSelect()));
+    refund.setVentilatedByUser(null);
+    refund.setVentilatedDate(null);
 
     List<InvoiceLine> refundLines = new ArrayList<InvoiceLine>();
     if (refund.getInvoiceLineList() != null) {


### PR DESCRIPTION
Setting ventilation info prevents to modify invoice date and is inconsistent.