### PR TITLE
CostSheet: improve price computation from WAP

### DIFF
--- a/axelor-production/src/main/java/com/axelor/apps/production/service/costsheet/CostSheetLineServiceImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/costsheet/CostSheetLineServiceImpl.java
@@ -298,6 +298,9 @@ public class CostSheetLineServiceImpl implements CostSheetLineService {
 
     if (componentsValuationMethod == ProductRepository.COMPONENTS_VALUATION_METHOD_AVERAGE) {
       price = weightedAveragePriceService.computeAvgPriceForCompany(product, company);
+      if (price == null || price.compareTo(BigDecimal.ZERO) == 0) {
+        price = weightedAveragePriceService.getNotWeightedAveragePricePerCompany(product, company);
+      }
 
       if (price == null || price.compareTo(BigDecimal.ZERO) == 0) {
         price = (BigDecimal) productCompanyService.get(product, "costPrice", company);
@@ -307,6 +310,9 @@ public class CostSheetLineServiceImpl implements CostSheetLineService {
 
       if (price == null || price.compareTo(BigDecimal.ZERO) == 0) {
         price = weightedAveragePriceService.computeAvgPriceForCompany(product, company);
+      }
+      if (price == null || price.compareTo(BigDecimal.ZERO) == 0) {
+        price = weightedAveragePriceService.getNotWeightedAveragePricePerCompany(product, company);
       }
     }
 

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/WeightedAveragePriceService.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/WeightedAveragePriceService.java
@@ -29,4 +29,15 @@ public interface WeightedAveragePriceService {
   public void computeAvgPriceForProduct(Product product) throws AxelorException;
 
   public BigDecimal computeAvgPriceForCompany(Product product, Company company);
+
+  /**
+   * Only used when we want to get WAP per company but there is no quantity available to compute the
+   * correct WAP. This method will simply take the average of WAP.
+   *
+   * @param product a product with the sum of quantities in stock locations from the given company
+   *     equals to 0
+   * @param company a company
+   * @return the average WAP from all stock location from the given company
+   */
+  BigDecimal getNotWeightedAveragePricePerCompany(Product product, Company company);
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/WeightedAveragePriceServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/WeightedAveragePriceServiceImpl.java
@@ -33,7 +33,9 @@ import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import com.google.inject.servlet.RequestScoped;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @RequestScoped
@@ -133,7 +135,28 @@ public class WeightedAveragePriceServiceImpl implements WeightedAveragePriceServ
     if (qtyTot.compareTo(BigDecimal.ZERO) == 0) {
       return BigDecimal.ZERO;
     }
-    productAvgPrice = productAvgPrice.divide(qtyTot, scale, BigDecimal.ROUND_HALF_UP);
+    productAvgPrice = productAvgPrice.divide(qtyTot, scale, RoundingMode.HALF_UP);
     return productAvgPrice;
+  }
+
+  @Override
+  public BigDecimal getNotWeightedAveragePricePerCompany(Product product, Company company) {
+    String query =
+        "SELECT AVG(self.avgPrice) "
+            + "FROM StockLocationLine self "
+            + "WHERE self.product.id = :productId "
+            + "AND self.stockLocation.typeSelect != :typeVirtual "
+            + "AND self.stockLocation.company.id = :companyId";
+    BigDecimal avgResult =
+        BigDecimal.valueOf(
+            Optional.ofNullable(
+                    JPA.em()
+                        .createQuery(query, Double.class)
+                        .setParameter("productId", product.getId())
+                        .setParameter("typeVirtual", StockLocationRepository.TYPE_VIRTUAL)
+                        .setParameter("companyId", company.getId())
+                        .getSingleResult())
+                .orElse(0d));
+    return avgResult.setScale(appBaseService.getNbDecimalDigitForUnitPrice(), RoundingMode.HALF_UP);
   }
 }


### PR DESCRIPTION
When we use WAP to get the cost of a component, sometimes we cannot have
its correct WAP per company because there are no quantities in stock.
Now when this happens, we get the average price between existing wap
price in stock location linked to the correct company.
Fixes RM27102