### PR TITLE
Feature #31437 Added an alert message before the invoice's ventilation process if the total invoiced amount overcome the total amount of the linked sale

### DIFF
--- a/axelor-supplychain/src/main/resources/views/Invoice.xml
+++ b/axelor-supplychain/src/main/resources/views/Invoice.xml
@@ -3,6 +3,15 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://axelor.com/xml/ns/object-views http://axelor.com/xml/ns/object-views/object-views_5.3.xsd">
 
+  <form name="invoice-form" extension="true" model="com.axelor.apps.account.db.Invoice" id="invoice-form-supply-chain" title="Invoice" >
+  		<extend target="//button[@name='ventilateBtn']">
+  			<attribute name="onClick" value="save,action-invoice-method-check-not-lettered-advance-payment-move-lines,action-invoice-method-check-not-imputed-refunds,action-invoice-validate-if-order,action-invoice-method-ventilate,save"/>
+  		</extend>
+  		<extend target="//button[@name='validateAndVentilateBtn']">
+  			<attribute name="onClick" value="save,action-validate-invoice-ckeck-invoice-line-tax-list,action-validate-invoice-ckeck-invoice-line-tax-list,action-invoice-method-check-not-lettered-advance-payment-move-lines,action-invoice-method-check-not-imputed-refunds,action-invoice-validate-if-order,action-invoice-method-validate-and-ventilate"/>
+  		</extend>
+  </form>
+
     <grid name="subscription-so-invoice-grid" title="Invoices" model="com.axelor.apps.account.db.Invoice" orderBy="-invoiceDate">
     	<field name="subscriptionFromDate" />
     	<field name="subscriptionToDate" />
@@ -17,6 +26,10 @@
     
     <action-validate name="action-invoice-validate-pfp-stock-move">
     	<alert message="At least one stock move is in litigation, do you really want to validate passed for payment ?" if="__repo__(StockMove).all().filter(' ? MEMBER OF self.invoiceSet and self.pfpValidateStatusSelect = 3',id).fetch().size &gt;= 1"/>
+    </action-validate>
+    
+    <action-validate name="action-invoice-validate-if-order">
+    	<alert message="The total invoiced amount overcome the total amount of the linked sale order, do you still wish to ventilate the order ?" if="saleOrder != null &amp;&amp; saleOrder.inTaxTotal &lt; inTaxTotal"/>
     </action-validate>
     
 </object-views>


### PR DESCRIPTION
-Added an override for the invoice form view on the supply-chain module

-Added an action validate that shows an alert if there is a linked sale order and the total amount of the invoice is higher than the total amount of the linked sale order

Feature #31437