### PR TITLE
Wap history: add new origin string field

### DIFF
--- a/axelor-stock/src/main/java/com/axelor/apps/stock/module/StockModule.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/module/StockModule.java
@@ -65,6 +65,8 @@ import com.axelor.apps.stock.service.StockRulesService;
 import com.axelor.apps.stock.service.StockRulesServiceImpl;
 import com.axelor.apps.stock.service.TrackingNumberConfigurationService;
 import com.axelor.apps.stock.service.TrackingNumberConfigurationServiceImpl;
+import com.axelor.apps.stock.service.WapHistoryService;
+import com.axelor.apps.stock.service.WapHistoryServiceImpl;
 import com.axelor.apps.stock.service.WeightedAveragePriceService;
 import com.axelor.apps.stock.service.WeightedAveragePriceServiceImpl;
 import com.axelor.apps.stock.service.app.AppStockService;
@@ -109,5 +111,6 @@ public class StockModule extends AxelorModule {
     bind(StockHistoryService.class).to(StockHistoryServiceImpl.class);
     bind(StockCorrectionRepository.class).to(StockCorrectionStockRepository.class);
     bind(TrackingNumberConfigurationService.class).to(TrackingNumberConfigurationServiceImpl.class);
+    bind(WapHistoryService.class).to(WapHistoryServiceImpl.class);
   }
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockLocationLineServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/StockLocationLineServiceImpl.java
@@ -26,17 +26,13 @@ import com.axelor.apps.stock.db.StockLocationLine;
 import com.axelor.apps.stock.db.StockMoveLine;
 import com.axelor.apps.stock.db.StockRules;
 import com.axelor.apps.stock.db.TrackingNumber;
-import com.axelor.apps.stock.db.WapHistory;
 import com.axelor.apps.stock.db.repo.StockLocationLineRepository;
 import com.axelor.apps.stock.db.repo.StockLocationRepository;
 import com.axelor.apps.stock.db.repo.StockMoveLineRepository;
 import com.axelor.apps.stock.db.repo.StockMoveRepository;
 import com.axelor.apps.stock.db.repo.StockRulesRepository;
-import com.axelor.apps.stock.db.repo.WapHistoryRepository;
 import com.axelor.apps.stock.exception.IExceptionMessage;
 import com.axelor.apps.tool.StringTool;
-import com.axelor.auth.AuthUtils;
-import com.axelor.auth.db.User;
 import com.axelor.db.Query;
 import com.axelor.exception.AxelorException;
 import com.axelor.exception.db.repo.TraceBackRepository;
@@ -50,7 +46,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +62,7 @@ public class StockLocationLineServiceImpl implements StockLocationLineService {
 
   protected AppBaseService appBaseService;
 
-  protected WapHistoryRepository wapHistoryRepo;
+  protected WapHistoryService wapHistoryService;
 
   protected UnitConversionService unitConversionService;
 
@@ -77,13 +72,13 @@ public class StockLocationLineServiceImpl implements StockLocationLineService {
       StockRulesService stockRulesService,
       StockMoveLineRepository stockMoveLineRepository,
       AppBaseService appBaseService,
-      WapHistoryRepository wapHistoryRepo,
+      WapHistoryService wapHistoryService,
       UnitConversionService unitConversionService) {
     this.stockLocationLineRepo = stockLocationLineRepo;
     this.stockRulesService = stockRulesService;
     this.stockMoveLineRepository = stockMoveLineRepository;
     this.appBaseService = appBaseService;
-    this.wapHistoryRepo = wapHistoryRepo;
+    this.wapHistoryService = wapHistoryService;
     this.unitConversionService = unitConversionService;
   }
 
@@ -772,18 +767,6 @@ public class StockLocationLineServiceImpl implements StockLocationLineService {
   public void updateWap(
       StockLocationLine stockLocationLine, BigDecimal wap, StockMoveLine stockMoveLine) {
     stockLocationLine.setAvgPrice(wap);
-    wapHistoryRepo.save(
-        new WapHistory(
-            stockLocationLine,
-            appBaseService.getTodayDate(
-                stockLocationLine.getStockLocation() != null
-                    ? stockLocationLine.getStockLocation().getCompany()
-                    : Optional.ofNullable(AuthUtils.getUser())
-                        .map(User::getActiveCompany)
-                        .orElse(null)),
-            wap,
-            stockLocationLine.getCurrentQty(),
-            stockLocationLine.getUnit(),
-            stockMoveLine));
+    wapHistoryService.saveWapHistory(stockLocationLine, stockMoveLine);
   }
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/WapHistoryService.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/WapHistoryService.java
@@ -1,0 +1,32 @@
+package com.axelor.apps.stock.service;
+
+import com.axelor.apps.stock.db.StockLocationLine;
+import com.axelor.apps.stock.db.StockMoveLine;
+import com.axelor.apps.stock.db.WapHistory;
+
+public interface WapHistoryService {
+
+  /**
+   * Create a new wap history line in given stock location line. The WAP ({@link
+   * StockLocationLine#avgPrice} must already be updated in the stock location line.
+   *
+   * <p>The origin will be {@link
+   * com.axelor.apps.stock.db.repo.WapHistoryRepository#ORIGIN_MANUAL_CORRECTION}
+   *
+   * @param stockLocationLine a stock location line with updated WAP
+   * @return the saved wap history
+   */
+  WapHistory saveWapHistory(StockLocationLine stockLocationLine);
+
+  /**
+   * Create a new wap history line in given stock location line. The WAP ({@link
+   * StockLocationLine#avgPrice} must already be updated in the stock location line.
+   *
+   * <p>Set the origin using given stock move line.
+   *
+   * @param stockLocationLine a stock location line with updated WAP
+   * @param stockMoveLine the stock move line that caused the WAP change
+   * @return the saved wap history
+   */
+  WapHistory saveWapHistory(StockLocationLine stockLocationLine, StockMoveLine stockMoveLine);
+}

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/WapHistoryServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/WapHistoryServiceImpl.java
@@ -1,0 +1,77 @@
+package com.axelor.apps.stock.service;
+
+import com.axelor.apps.base.service.app.AppBaseService;
+import com.axelor.apps.stock.db.StockLocationLine;
+import com.axelor.apps.stock.db.StockMove;
+import com.axelor.apps.stock.db.StockMoveLine;
+import com.axelor.apps.stock.db.WapHistory;
+import com.axelor.apps.stock.db.repo.WapHistoryRepository;
+import com.axelor.auth.AuthUtils;
+import com.axelor.auth.db.User;
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import java.time.LocalDate;
+import java.util.Optional;
+
+/** Service used for wap history creation in stock location line. */
+public class WapHistoryServiceImpl implements WapHistoryService {
+
+  protected WapHistoryRepository wapHistoryRepository;
+  protected AppBaseService appBaseService;
+
+  @Inject
+  public WapHistoryServiceImpl(
+      WapHistoryRepository wapHistoryRepository, AppBaseService appBaseService) {
+    this.wapHistoryRepository = wapHistoryRepository;
+    this.appBaseService = appBaseService;
+  }
+
+  @Override
+  @Transactional
+  public WapHistory saveWapHistory(
+      StockLocationLine stockLocationLine, StockMoveLine stockMoveLine) {
+    return wapHistoryRepository.save(createWapHistory(stockLocationLine, stockMoveLine));
+  }
+
+  @Override
+  @Transactional
+  public WapHistory saveWapHistory(StockLocationLine stockLocationLine) {
+    return wapHistoryRepository.save(createWapHistory(stockLocationLine));
+  }
+
+  /** Create a wap history when the wap change is manual, so no stock move line. */
+  protected WapHistory createWapHistory(StockLocationLine stockLocationLine) {
+    return createWapHistory(stockLocationLine, null, WapHistoryRepository.ORIGIN_MANUAL_CORRECTION);
+  }
+
+  /** Create a wap history when the wap change is from a stock move realization. */
+  protected WapHistory createWapHistory(
+      StockLocationLine stockLocationLine, StockMoveLine stockMoveLine) {
+    String origin =
+        Optional.ofNullable(stockMoveLine)
+            .map(StockMoveLine::getStockMove)
+            .map(StockMove::getStockMoveSeq)
+            .orElse("");
+    return createWapHistory(stockLocationLine, stockMoveLine, origin);
+  }
+
+  /** Use current value of stock location line to create a wap history. */
+  protected WapHistory createWapHistory(
+      StockLocationLine stockLocationLine, StockMoveLine stockMoveLine, String origin) {
+    LocalDate today =
+        appBaseService.getTodayDate(
+            stockLocationLine.getStockLocation() != null
+                ? stockLocationLine.getStockLocation().getCompany()
+                : Optional.ofNullable(AuthUtils.getUser())
+                    .map(User::getActiveCompany)
+                    .orElse(null));
+    return new WapHistory(
+        stockLocationLine,
+        today,
+        stockLocationLine.getAvgPrice(),
+        stockLocationLine.getCurrentQty(),
+        stockLocationLine.getUnit(),
+        origin,
+        stockMoveLine);
+  }
+}

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/translation/ITranslation.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/translation/ITranslation.java
@@ -26,4 +26,6 @@ public interface ITranslation {
 
   public static final String PICKING_STOCK_MOVE_NOTE = /*$$(*/ "PickingStockMove.note"; /*)*/
   public static final String STOCK_ON_TIME_DELIVERIES = /*$$(*/ "OnTime Deliveries"; /*)*/
+
+  String MANUAL_CORRECTION = /*$$(*/ "value:Manual correction"; /*)*/
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/web/StockLocationLineController.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/web/StockLocationLineController.java
@@ -1,0 +1,24 @@
+package com.axelor.apps.stock.web;
+
+import com.axelor.apps.stock.db.StockLocationLine;
+import com.axelor.apps.stock.db.repo.StockLocationLineRepository;
+import com.axelor.apps.stock.service.WapHistoryService;
+import com.axelor.exception.service.TraceBackService;
+import com.axelor.inject.Beans;
+import com.axelor.rpc.ActionRequest;
+import com.axelor.rpc.ActionResponse;
+
+public class StockLocationLineController {
+
+  public void addWapHistoryLine(ActionRequest request, ActionResponse response) {
+    try {
+      StockLocationLine stockLocationLine = request.getContext().asType(StockLocationLine.class);
+      stockLocationLine =
+          Beans.get(StockLocationLineRepository.class).find(stockLocationLine.getId());
+      Beans.get(WapHistoryService.class).saveWapHistory(stockLocationLine);
+      response.setReload(true);
+    } catch (Exception e) {
+      TraceBackService.trace(response, e);
+    }
+  }
+}

--- a/axelor-stock/src/main/resources/domains/WapHistory.xml
+++ b/axelor-stock/src/main/resources/domains/WapHistory.xml
@@ -11,6 +11,13 @@
     <decimal name="wap" title="WAP" precision="20" scale="10" readonly="true" initParam="true"/>
     <decimal name="qty" title="Quantity" precision="20" scale="10" readonly="true" initParam="true"/>
     <many-to-one name="unit" ref="com.axelor.apps.base.db.Unit" title="Unit" readonly="true" initParam="true"/>
+    <string name="origin" title="Origin" readonly="true" translatable="true" initParam="true"/>
     <many-to-one name="stockMoveLine" ref="com.axelor.apps.stock.db.StockMoveLine" title="Stock move line" readonly="true" initParam="true"/>
+
+    <extra-code><![CDATA[
+      //origin
+      public static final String ORIGIN_MANUAL_CORRECTION = "Manual correction";
+    ]]></extra-code>
   </entity>
+
 </domain-models>

--- a/axelor-stock/src/main/resources/i18n/messages.csv
+++ b/axelor-stock/src/main/resources/i18n/messages.csv
@@ -886,5 +886,6 @@
 "important",,,
 "info",,,
 "success",,,
+"value:Manual correction",,,
 "value:Stock",,,
 "warning",,,

--- a/axelor-stock/src/main/resources/i18n/messages_en.csv
+++ b/axelor-stock/src/main/resources/i18n/messages_en.csv
@@ -886,5 +886,6 @@
 "important",,,
 "info",,,
 "success",,,
+"value:Manual correction",,,
 "value:Stock",,,
 "warning",,,

--- a/axelor-stock/src/main/resources/i18n/messages_fr.csv
+++ b/axelor-stock/src/main/resources/i18n/messages_fr.csv
@@ -886,5 +886,6 @@
 "important",,,
 "info",,,
 "success","succès",,
+"value:Manual correction","Correction manuelle",,
 "value:Stock","Stock",,
 "warning","avertissement",,

--- a/axelor-stock/src/main/resources/views/StockLocationLine.xml
+++ b/axelor-stock/src/main/resources/views/StockLocationLine.xml
@@ -20,7 +20,7 @@
     	<panel name="mainPanel">
 	        <field name="product" canEdit="false" form-view="product-form" grid-view="product-grid" domain="self.dtype = 'Product'"/>
 	        <field name="unit" form-view="unit-form" grid-view="unit-grid"/>
-            <field name="avgPrice" colSpan="3" readonlyIf="!$isAvgPriceEditable"/>
+            <field name="avgPrice" colSpan="3" onChange="action-stock-location-line-group-avg-price-onchange" readonlyIf="!$isAvgPriceEditable"/>
             <field name="$isAvgPriceEditable" hidden="true" type="boolean"/>
             <button name="updateAvgPriceBtn" title="Update average price" onClick="action-stock-location-line-attrs-update-avg-price"  colSpan="3" hideIf="( stockLocation &amp;&amp; stockLocation.typeSelect == 3 ) || $readonly() || (!$readonly() &amp;&amp; $isAvgPriceEditable)"/>
             <field name="rack"/>
@@ -69,7 +69,7 @@
             <field name="currentQty" colSpan="4"/>
             <field name="futureQty" colSpan="4"/>
             <field name="unit" form-view="unit-form" grid-view="unit-grid"/>
-            <field name="avgPrice" colSpan="3" readonlyIf="!$isAvgPriceEditable"/>
+            <field name="avgPrice" onChange="action-stock-location-line-group-avg-price-onchange" colSpan="3" readonlyIf="!$isAvgPriceEditable"/>
             <field name="$isAvgPriceEditable" hidden="true" type="boolean"/>
             <button name="updateAvgPriceBtn" title="Update average price" onClick="action-stock-location-line-attrs-update-avg-price"  colSpan="3" hideIf="( stockLocation &amp;&amp; stockLocation.typeSelect == 3 ) || $readonly() || (!$readonly() &amp;&amp; $isAvgPriceEditable)"/>
             <field name="rack"/>
@@ -92,7 +92,7 @@
 	        <field name="product" form-view="product-form" grid-view="product-grid" domain="self.dtype = 'Product'"/>
 	        <field name="stockLocation" form-view="stock-location-form" grid-view="stock-location-grid"/>
 	        <field name="unit" form-view="unit-form" grid-view="unit-grid"/>
-            <field name="avgPrice" colSpan="3" readonlyIf="!$isAvgPriceEditable"/>
+            <field name="avgPrice" onChange="action-stock-location-line-group-avg-price-onchange" colSpan="3" readonlyIf="!$isAvgPriceEditable"/>
             <field name="$isAvgPriceEditable" hidden="true" type="boolean"/>
             <button name="updateAvgPriceBtn" title="Update average price" onClick="action-stock-location-line-attrs-update-avg-price"  colSpan="3" hideIf="( stockLocation &amp;&amp; stockLocation.typeSelect == 3 ) || $readonly() || (!$readonly() &amp;&amp; $isAvgPriceEditable)"/>
 	        <field name="lastFutureStockMoveDate"/>
@@ -141,7 +141,7 @@
 	        <field name="currentQty"/>
 	        <field name="futureQty"/>
 	        <field name="unit" form-view="unit-form" grid-view="unit-grid"/>
-            <field name="avgPrice"/>
+            <field name="avgPrice" onChange="action-stock-location-line-group-avg-price-onchange"/>
             <field name="reservedQty" if-module="axelor-supplychain" if="__config__.app.getApp('supplychain').getManageStockReservation()"/>
 	        <field name="trackingNumber" domain="self.product = :product"/>
             <field name="rack"/>
@@ -167,6 +167,11 @@
     
     <action-group name="action-stock-location-line-group-onnew">
     	<action name="action-stock-location-line-attrs-scale-and-precision"/>
+    </action-group>
+
+    <action-group name="action-stock-location-line-group-avg-price-onchange">
+      <action name="save"/>
+      <action name="action-stock-location-line-method-add-wap-history-line"/>
     </action-group>
     
     <action-view name="action-stock-location-line-view-product-qty" title="Location content" model="com.axelor.apps.stock.db.StockLocationLine">
@@ -246,12 +251,7 @@
 		<context name="_stockLocationLineId" expr="eval: id"/>
     </action-view>
 
-	<action-method name="action-stock-location-line-allocate-all">
-	  <call class="com.axelor.apps.supplychain.web.StockLocationLineController" method="allocateAll"/>
-	</action-method>
-
-	<action-method name="action-stock-location-line-deallocate-all">
-	  <call class="com.axelor.apps.supplychain.web.StockLocationLineController" method="deallocateAll"/>
-	</action-method>
-
+  <action-method name="action-stock-location-line-method-add-wap-history-line">
+    <call class="com.axelor.apps.stock.web.StockLocationLineController" method="addWapHistoryLine"/>
+  </action-method>
 </object-views>

--- a/axelor-stock/src/main/resources/views/WapHistory.xml
+++ b/axelor-stock/src/main/resources/views/WapHistory.xml
@@ -8,6 +8,7 @@
     <field name="wap"/>
     <field name="qty" x-scale="2"/>
     <field name="unit"/>
+    <field name="origin"/>
   </grid>
 
   <form name="wap-history-form" title="WAP history" model="com.axelor.apps.stock.db.WapHistory"
@@ -17,7 +18,8 @@
       <field name="wap"/>
       <field name="qty"/>
       <field name="unit"/>
-      <field name="stockMoveLine" showIf="stockMoveLine" form-view="stock-move-line-all-form" grid-view="stock-move-line-grid"/>
+      <field name="origin" colSpan="12" showIf="!stockMoveLine"/>
+      <field name="stockMoveLine.stockMove" title="Origin" colSpan="12" showIf="stockMoveLine" form-view="stock-move-form" grid-view="stock-move-grid"/>
     </panel>
   </form>
   

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockLocationLineServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockLocationLineServiceSupplychainImpl.java
@@ -25,9 +25,9 @@ import com.axelor.apps.stock.db.StockLocationLine;
 import com.axelor.apps.stock.db.TrackingNumber;
 import com.axelor.apps.stock.db.repo.StockLocationLineRepository;
 import com.axelor.apps.stock.db.repo.StockMoveLineRepository;
-import com.axelor.apps.stock.db.repo.WapHistoryRepository;
 import com.axelor.apps.stock.service.StockLocationLineServiceImpl;
 import com.axelor.apps.stock.service.StockRulesService;
+import com.axelor.apps.stock.service.WapHistoryService;
 import com.axelor.apps.supplychain.exception.IExceptionMessage;
 import com.axelor.apps.supplychain.service.app.AppSupplychainService;
 import com.axelor.exception.AxelorException;
@@ -49,7 +49,7 @@ public class StockLocationLineServiceSupplychainImpl extends StockLocationLineSe
       StockRulesService stockRulesService,
       StockMoveLineRepository stockMoveLineRepository,
       AppBaseService appBaseService,
-      WapHistoryRepository wapHistoryRepo,
+      WapHistoryService wapHistoryService,
       UnitConversionService unitConversionService,
       AppSupplychainService appSupplychainService) {
     super(
@@ -57,7 +57,7 @@ public class StockLocationLineServiceSupplychainImpl extends StockLocationLineSe
         stockRulesService,
         stockMoveLineRepository,
         appBaseService,
-        wapHistoryRepo,
+        wapHistoryService,
         unitConversionService);
     this.appSupplychainService = appSupplychainService;
   }

--- a/axelor-supplychain/src/main/resources/views/StockLocationLine.xml
+++ b/axelor-supplychain/src/main/resources/views/StockLocationLine.xml
@@ -28,5 +28,13 @@
         <context name="location" expr="eval: __stockLocationIdList"/>
         <context name="companyId" expr="eval: company?.id "/>
     </action-view>
-    
+
+  <action-method name="action-stock-location-line-allocate-all">
+    <call class="com.axelor.apps.supplychain.web.StockLocationLineController" method="allocateAll"/>
+  </action-method>
+
+  <action-method name="action-stock-location-line-deallocate-all">
+    <call class="com.axelor.apps.supplychain.web.StockLocationLineController" method="deallocateAll"/>
+  </action-method>
+
 </object-views>	

--- a/changelogs/unreleased/wap-history-add-origin.yml
+++ b/changelogs/unreleased/wap-history-add-origin.yml
@@ -1,0 +1,3 @@
+---
+title: "Wap history: add a new field to show the origin of a wap variation in a stock location line form view."
+type: change


### PR DESCRIPTION
The origin string field contains either "manual correction" if changed
from the view or the sequence of the stock move that caused the WAP
value change.

RM37423