### PR TITLE
Sequence: fix increment on exception

### DIFF
--- a/changelogs/unreleased/fix-sequence-incrementing-on-exception.yml
+++ b/changelogs/unreleased/fix-sequence-incrementing-on-exception.yml
@@ -1,0 +1,3 @@
+---
+title: "Sequence: fixed issue where the sequence count would increment after an exception cancelling the process."
+type: fix


### PR DESCRIPTION
Instead of using a separate thread for incrementing sequence, we use a
database lock so any thread will wait for a given sequence to be
available before modifying it.
RM45139