### PR TITLE
MRP: fix NPE during computation

### DIFF
--- a/axelor-production/src/main/java/com/axelor/apps/production/service/MrpServiceProductionImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/MrpServiceProductionImpl.java
@@ -487,11 +487,12 @@ public class MrpServiceProductionImpl extends MrpServiceImpl {
       return;
     }
 
-    log.debug("Add of the product : {}", product.getFullName());
-    this.productMap.put(product.getId(), this.getMaxLevel(product, 0));
-
-    if (product.getDefaultBillOfMaterial() != null) {
+    if (product.getDefaultBillOfMaterial() != null
+        && mrp.getMrpTypeSelect() == MrpRepository.MRP_TYPE_MRP) {
       this.assignProductLevel(product.getDefaultBillOfMaterial(), 0);
+    } else {
+      log.debug("Add product: {}", product.getFullName());
+      this.productMap.put(product.getId(), this.getMaxLevel(product, 0));
     }
   }
 
@@ -527,19 +528,14 @@ public class MrpServiceProductionImpl extends MrpServiceImpl {
       }
     }
 
-    if (billOfMaterial.getBillOfMaterialSet() == null
-        || billOfMaterial.getBillOfMaterialSet().isEmpty()) {
+    Product product = billOfMaterial.getProduct();
 
-      Product subProduct = billOfMaterial.getProduct();
+    log.debug("Add product: {} for the level : {} ", product.getFullName(), level);
+    this.productMap.put(product.getId(), this.getMaxLevel(product, level));
 
-      if (mrp.getMrpTypeSelect() == MrpRepository.MRP_TYPE_MRP) {
-        log.debug(
-            "Add of the sub product : {} for the level : {} ", subProduct.getFullName(), level);
-        this.productMap.put(subProduct.getId(), this.getMaxLevel(subProduct, level));
-      }
-    } else {
-
-      level = level + 1;
+    level = level + 1;
+    if (billOfMaterial.getBillOfMaterialSet() != null
+        && !billOfMaterial.getBillOfMaterialSet().isEmpty()) {
 
       for (BillOfMaterial subBillOfMaterial : billOfMaterial.getBillOfMaterialSet()) {
 

--- a/changelogs/unreleased/fix-npe-mrp-computation.yml
+++ b/changelogs/unreleased/fix-npe-mrp-computation.yml
@@ -1,0 +1,3 @@
+---
+title: "MRP: fix NPE during computation when having multiple BOM levels."
+type: fix


### PR DESCRIPTION
NPE occured when having multiple BOM level: intermediate levels are not
added to the productMap, and cause a NPE later.
RM24332