### PR TITLE
Exception: fix error message on save

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/AccountAccountRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/AccountAccountRepository.java
@@ -58,7 +58,7 @@ public class AccountAccountRepository extends AccountRepository {
       return super.save(account);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/AccountingReportManagementRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/AccountingReportManagementRepository.java
@@ -41,7 +41,7 @@ public class AccountingReportManagementRepository extends AccountingReportReposi
       return super.save(accountingReport);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/DebtRecoveryAccountRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/DebtRecoveryAccountRepository.java
@@ -34,7 +34,7 @@ public class DebtRecoveryAccountRepository extends DebtRecoveryRepository {
       return super.save(debtRecovery);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/DepositSlipAccountRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/DepositSlipAccountRepository.java
@@ -43,7 +43,7 @@ public class DepositSlipAccountRepository extends DepositSlipRepository {
       return super.save(entity);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/FixedAssetManagementRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/FixedAssetManagementRepository.java
@@ -36,7 +36,7 @@ public class FixedAssetManagementRepository extends FixedAssetRepository {
       return super.save(fixedAsset);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 
@@ -48,7 +48,7 @@ public class FixedAssetManagementRepository extends FixedAssetRepository {
             Beans.get(SequenceService.class).getDraftSequenceNumber(fixedAsset));
       }
     } catch (Exception e) {
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/InvoiceManagementRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/InvoiceManagementRepository.java
@@ -63,7 +63,7 @@ public class InvoiceManagementRepository extends InvoiceRepository {
       return invoice;
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/InvoicePaymentManagementRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/InvoicePaymentManagementRepository.java
@@ -32,7 +32,7 @@ public class InvoicePaymentManagementRepository extends InvoicePaymentRepository
       return super.save(invoicePayment);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/MoveLineManagementRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/MoveLineManagementRepository.java
@@ -40,7 +40,7 @@ public class MoveLineManagementRepository extends MoveLineRepository {
             I18n.get(IExceptionMessage.MOVE_REMOVE_NOT_OK),
             entity.getMove().getReference());
       } catch (AxelorException e) {
-        throw new PersistenceException(e);
+        throw new PersistenceException(e.getMessage(), e);
       }
     } else {
       super.remove(entity);
@@ -60,7 +60,7 @@ public class MoveLineManagementRepository extends MoveLineRepository {
       Beans.get(MoveLineService.class).validateMoveLine(entity);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
     return super.save(entity);
   }

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/MoveManagementRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/MoveManagementRepository.java
@@ -52,7 +52,7 @@ public class MoveManagementRepository extends MoveRepository {
           Beans.get(PeriodService.class)
               .getActivePeriod(copy.getDate(), entity.getCompany(), YearRepository.TYPE_FISCAL);
     } catch (AxelorException e) {
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
     copy.setStatusSelect(STATUS_NEW);
     copy.setTechnicalOriginSelect(MoveRepository.TECHNICAL_ORIGIN_ENTRY);
@@ -119,7 +119,7 @@ public class MoveManagementRepository extends MoveRepository {
       return super.save(move);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 
@@ -133,7 +133,7 @@ public class MoveManagementRepository extends MoveRepository {
             I18n.get(IExceptionMessage.MOVE_REMOVE_NOT_OK),
             entity.getReference());
       } catch (AxelorException e) {
-        throw new PersistenceException(e);
+        throw new PersistenceException(e.getMessage(), e);
       }
     } else {
       super.remove(entity);

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/PartnerAccountRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/PartnerAccountRepository.java
@@ -67,7 +67,7 @@ public class PartnerAccountRepository extends PartnerBaseRepository {
       return super.save(partner);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/PaymentVoucherManagementRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/PaymentVoucherManagementRepository.java
@@ -63,7 +63,7 @@ public class PaymentVoucherManagementRepository extends PaymentVoucherRepository
       return super.save(paymentVoucher);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 
@@ -75,7 +75,7 @@ public class PaymentVoucherManagementRepository extends PaymentVoucherRepository
             TraceBackRepository.CATEGORY_CONFIGURATION_ERROR,
             I18n.get(IExceptionMessage.PAYMENT_VOUCHER_REMOVE_NOT_OK));
       } catch (AxelorException e) {
-        throw new PersistenceException(e);
+        throw new PersistenceException(e.getMessage(), e);
       }
     }
     super.remove(entity);

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/ReconcileGroupAccountRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/ReconcileGroupAccountRepository.java
@@ -36,7 +36,7 @@ public class ReconcileGroupAccountRepository extends ReconcileGroupRepository {
       return super.save(reconcileGroup);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-account/src/main/java/com/axelor/apps/account/db/repo/ReconcileManagementRepository.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/db/repo/ReconcileManagementRepository.java
@@ -38,7 +38,7 @@ public class ReconcileManagementRepository extends ReconcileRepository {
       return super.save(reconcile);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 
@@ -65,7 +65,7 @@ public class ReconcileManagementRepository extends ReconcileRepository {
             I18n.get(IExceptionMessage.RECONCILE_CAN_NOT_BE_REMOVE),
             entity.getReconcileSeq());
       } catch (AxelorException e) {
-        throw new PersistenceException(e);
+        throw new PersistenceException(e.getMessage(), e);
       }
     } else {
       super.remove(entity);

--- a/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/db/repo/BankOrderManagementRepository.java
+++ b/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/db/repo/BankOrderManagementRepository.java
@@ -42,7 +42,7 @@ public class BankOrderManagementRepository extends BankOrderRepository {
       return super.save(entity);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-base/src/main/java/com/axelor/apps/base/db/repo/AddressBaseRepository.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/db/repo/AddressBaseRepository.java
@@ -35,7 +35,7 @@ public class AddressBaseRepository extends AddressRepository {
       addressService.updateLatLong(entity);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
 
     return super.save(entity);

--- a/axelor-base/src/main/java/com/axelor/apps/base/db/repo/DurationBaseRepository.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/db/repo/DurationBaseRepository.java
@@ -33,7 +33,7 @@ public class DurationBaseRepository extends DurationRepository {
       return super.save(duration);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-base/src/main/java/com/axelor/apps/base/db/repo/PartnerBaseRepository.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/db/repo/PartnerBaseRepository.java
@@ -37,7 +37,7 @@ public class PartnerBaseRepository extends PartnerRepository {
       return super.save(partner);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-base/src/main/java/com/axelor/apps/base/db/repo/ProductBaseRepository.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/db/repo/ProductBaseRepository.java
@@ -55,7 +55,7 @@ public class ProductBaseRepository extends ProductRepository {
       }
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
 
     product.setFullName(String.format(FULL_NAME_FORMAT, product.getCode(), product.getName()));
@@ -112,7 +112,7 @@ public class ProductBaseRepository extends ProductRepository {
       }
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
     return copy;
   }

--- a/axelor-base/src/main/java/com/axelor/apps/base/db/repo/UserBaseRepository.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/db/repo/UserBaseRepository.java
@@ -57,7 +57,7 @@ public class UserBaseRepository extends UserRepository {
       return user;
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-cash-management/src/main/java/com/axelor/apps/cash/management/db/repo/CashManagementForecastRecapRepository.java
+++ b/axelor-cash-management/src/main/java/com/axelor/apps/cash/management/db/repo/CashManagementForecastRecapRepository.java
@@ -59,7 +59,7 @@ public class CashManagementForecastRecapRepository extends ForecastRecapReposito
       return super.save(entity);
     } catch (AxelorException e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-cash-management/src/main/java/com/axelor/apps/cash/management/db/repo/CashManagementForecastRepository.java
+++ b/axelor-cash-management/src/main/java/com/axelor/apps/cash/management/db/repo/CashManagementForecastRepository.java
@@ -57,7 +57,7 @@ public class CashManagementForecastRepository extends ForecastRepository {
       return super.save(entity);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-contract/src/main/java/com/axelor/apps/contract/db/repo/ContractRepository.java
+++ b/axelor-contract/src/main/java/com/axelor/apps/contract/db/repo/ContractRepository.java
@@ -42,7 +42,7 @@ public class ContractRepository extends AbstractContractRepository {
       return super.save(contract);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 
@@ -61,7 +61,7 @@ public class ContractRepository extends AbstractContractRepository {
       }
       return seq;
     } catch (Exception e) {
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-crm/src/main/java/com/axelor/apps/crm/db/repo/OpportunityManagementRepository.java
+++ b/axelor-crm/src/main/java/com/axelor/apps/crm/db/repo/OpportunityManagementRepository.java
@@ -42,7 +42,7 @@ public class OpportunityManagementRepository extends OpportunityRepository {
       return super.save(opportunity);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-human-resource/src/main/java/com/axelor/apps/hr/db/repo/ExpenseHRRepository.java
+++ b/axelor-human-resource/src/main/java/com/axelor/apps/hr/db/repo/ExpenseHRRepository.java
@@ -36,7 +36,7 @@ public class ExpenseHRRepository extends ExpenseRepository {
       return expense;
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-human-resource/src/main/java/com/axelor/apps/hr/db/repo/TimesheetLineHRRepository.java
+++ b/axelor-human-resource/src/main/java/com/axelor/apps/hr/db/repo/TimesheetLineHRRepository.java
@@ -31,7 +31,7 @@ public class TimesheetLineHRRepository extends TimesheetLineRepository {
       return super.save(timesheetLine);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-production/src/main/java/com/axelor/apps/production/db/repo/ManufOrderManagementRepository.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/db/repo/ManufOrderManagementRepository.java
@@ -68,7 +68,7 @@ public class ManufOrderManagementRepository extends ManufOrderRepository {
       }
     } catch (AxelorException e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
 
     if (entity.getOperationOrderList() != null) {

--- a/axelor-production/src/main/java/com/axelor/apps/production/db/repo/RawMaterialRequirementProductionRepository.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/db/repo/RawMaterialRequirementProductionRepository.java
@@ -38,7 +38,7 @@ public class RawMaterialRequirementProductionRepository extends RawMaterialRequi
       return super.save(rawMaterialRequirement);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-production/src/main/java/com/axelor/apps/production/db/repo/UnitCostCalculationManagementRepository.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/db/repo/UnitCostCalculationManagementRepository.java
@@ -37,7 +37,7 @@ public class UnitCostCalculationManagementRepository extends UnitCostCalculation
       }
     } catch (AxelorException e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
 
     return super.save(entity);

--- a/axelor-project/src/main/java/com/axelor/apps/project/db/repo/ProjectManagementRepository.java
+++ b/axelor-project/src/main/java/com/axelor/apps/project/db/repo/ProjectManagementRepository.java
@@ -96,7 +96,7 @@ public class ProjectManagementRepository extends ProjectRepository {
       }
     } catch (AxelorException e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
     setAllProjectFullName(project);
 

--- a/axelor-purchase/src/main/java/com/axelor/apps/purchase/db/repo/PurchaseOrderManagementRepository.java
+++ b/axelor-purchase/src/main/java/com/axelor/apps/purchase/db/repo/PurchaseOrderManagementRepository.java
@@ -55,7 +55,7 @@ public class PurchaseOrderManagementRepository extends PurchaseOrderRepository {
       return purchaseOrder;
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-purchase/src/main/java/com/axelor/apps/purchase/db/repo/PurchaseRequestManagementRepository.java
+++ b/axelor-purchase/src/main/java/com/axelor/apps/purchase/db/repo/PurchaseRequestManagementRepository.java
@@ -48,7 +48,7 @@ public class PurchaseRequestManagementRepository extends PurchaseRequestReposito
       return super.save(entity);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/AdvancePaymentSaleRepository.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/AdvancePaymentSaleRepository.java
@@ -32,7 +32,7 @@ public class AdvancePaymentSaleRepository extends AdvancePaymentRepository {
       Beans.get(SaleOrderComputeService.class)._computeSaleOrder(saleOrder);
       return super.save(advancePayment);
     } catch (Exception e) {
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/ConfiguratorCreatorSaleRepository.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/ConfiguratorCreatorSaleRepository.java
@@ -53,7 +53,7 @@ public class ConfiguratorCreatorSaleRepository extends ConfiguratorCreatorReposi
       }
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/SaleOrderManagementRepository.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/db/repo/SaleOrderManagementRepository.java
@@ -98,7 +98,7 @@ public class SaleOrderManagementRepository extends SaleOrderRepository {
       return super.save(saleOrder);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 
@@ -115,7 +115,7 @@ public class SaleOrderManagementRepository extends SaleOrderRepository {
       }
 
     } catch (Exception e) {
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 
@@ -129,7 +129,7 @@ public class SaleOrderManagementRepository extends SaleOrderRepository {
         saleOrder.setFullName(fullName);
       }
     } catch (Exception e) {
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/db/repo/InventoryManagementRepository.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/db/repo/InventoryManagementRepository.java
@@ -48,7 +48,7 @@ public class InventoryManagementRepository extends InventoryRepository {
       }
     } catch (AxelorException e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
 
     entity.setInventoryTitle(Beans.get(InventoryService.class).computeTitle(entity));

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/db/repo/LogisticalFormStockRepository.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/db/repo/LogisticalFormStockRepository.java
@@ -79,7 +79,7 @@ public class LogisticalFormStockRepository extends LogisticalFormRepository {
 
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/db/repo/StockLocationLineStockRepository.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/db/repo/StockLocationLineStockRepository.java
@@ -36,7 +36,7 @@ public class StockLocationLineStockRepository extends StockLocationLineRepositor
       return super.save(entity);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/db/repo/StockMoveManagementRepository.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/db/repo/StockMoveManagementRepository.java
@@ -72,7 +72,7 @@ public class StockMoveManagementRepository extends StockMoveRepository {
       return stockMove;
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/AdvancePaymentSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/AdvancePaymentSupplychainRepository.java
@@ -39,7 +39,7 @@ public class AdvancePaymentSupplychainRepository extends AdvancePaymentSaleRepos
       return super.save(advancePayment);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/InvoiceSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/InvoiceSupplychainRepository.java
@@ -62,7 +62,7 @@ public class InvoiceSupplychainRepository extends InvoiceManagementRepository {
       return super.save(invoice);
     } catch (Exception e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/MrpManagementRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/MrpManagementRepository.java
@@ -63,7 +63,7 @@ public class MrpManagementRepository extends MrpRepository {
       }
     } catch (AxelorException e) {
       TraceBackService.traceExceptionFromSaveMethod(e);
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
 
     return super.save(entity);

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveLineSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveLineSupplychainRepository.java
@@ -63,7 +63,7 @@ public class StockMoveLineSupplychainRepository extends StockMoveLineStockReposi
         super.remove(stockMoveLine);
       }
     } catch (AxelorException e) {
-      throw new PersistenceException(e);
+      throw new PersistenceException(e.getMessage(), e);
     }
   }
 }

--- a/changelogs/unreleased/exception-management-on-save.yml
+++ b/changelogs/unreleased/exception-management-on-save.yml
@@ -1,0 +1,5 @@
+---
+title: "Exception: fix message display when an error occurs on save."
+type: fix
+description: |
+  "For example, the message 'Invoice type missing on invoice' is now correctly displayed instead of 'com.axelor.exception.AxelorException: Invoice type missing on invoice'"


### PR DESCRIPTION
When an exception is thrown inside a save method, on the exception
created to rethrow it, we now prevent the message to be prefixed by the
exception class name so it can be displayed to the user.
RM47077