### PR TITLE
RM47537 Use enum instead of int consts for ManufOrder originType

### DIFF
--- a/axelor-business-production/src/main/java/com/axelor/apps/businessproduction/service/ProductionOrderServiceBusinessImpl.java
+++ b/axelor-business-production/src/main/java/com/axelor/apps/businessproduction/service/ProductionOrderServiceBusinessImpl.java
@@ -23,6 +23,7 @@ import com.axelor.apps.production.db.BillOfMaterial;
 import com.axelor.apps.production.db.ProductionOrder;
 import com.axelor.apps.production.db.repo.ProductionOrderRepository;
 import com.axelor.apps.production.service.manuforder.ManufOrderService;
+import com.axelor.apps.production.service.manuforder.ManufOrderService.ManufOrderOriginTypeProduction;
 import com.axelor.apps.production.service.productionorder.ProductionOrderServiceImpl;
 import com.axelor.apps.project.db.Project;
 import com.axelor.apps.sale.db.SaleOrder;
@@ -67,7 +68,7 @@ public class ProductionOrderServiceBusinessImpl extends ProductionOrderServiceIm
         endDate,
         saleOrder,
         saleOrderLine,
-        ManufOrderService.ORIGIN_TYPE_OTHER);
+        ManufOrderOriginTypeProduction.ORIGIN_TYPE_OTHER);
 
     return productionOrderRepo.save(productionOrder);
   }

--- a/axelor-production/src/main/java/com/axelor/apps/production/service/MrpLineServiceProductionImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/MrpLineServiceProductionImpl.java
@@ -26,7 +26,7 @@ import com.axelor.apps.production.db.repo.ManufOrderRepository;
 import com.axelor.apps.production.db.repo.OperationOrderRepository;
 import com.axelor.apps.production.service.app.AppProductionService;
 import com.axelor.apps.production.service.manuforder.ManufOrderService;
-import com.axelor.apps.production.service.manuforder.ManufOrderServiceImpl;
+import com.axelor.apps.production.service.manuforder.ManufOrderService.ManufOrderOriginTypeProduction;
 import com.axelor.apps.purchase.db.PurchaseOrder;
 import com.axelor.apps.purchase.db.repo.PurchaseOrderLineRepository;
 import com.axelor.apps.purchase.db.repo.PurchaseOrderRepository;
@@ -121,7 +121,7 @@ public class MrpLineServiceProductionImpl extends MrpLineServiceImpl {
             null,
             mrpLine.getMaturityDate().atStartOfDay(),
             null,
-            ManufOrderServiceImpl
+            ManufOrderOriginTypeProduction
                 .ORIGIN_TYPE_MRP); // TODO compute the time to produce to put the manuf order at the
     // correct day
 

--- a/axelor-production/src/main/java/com/axelor/apps/production/service/manuforder/ManufOrderService.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/manuforder/ManufOrderService.java
@@ -37,24 +37,14 @@ public interface ManufOrderService {
   public static int DEFAULT_PRIORITY_INTERVAL = 10;
   public static boolean IS_TO_INVOICE = false;
 
-  public static int ORIGIN_TYPE_MRP = 1;
-  public static int ORIGIN_TYPE_SALE_ORDER = 2;
-  public static int ORIGIN_TYPE_OTHER = 3;
+  public interface ManufOrderOriginType {}
 
-  /**
-   * @param product
-   * @param qtyRequested
-   * @param priority
-   * @param isToInvoice
-   * @param billOfMaterial
-   * @param plannedStartDateT
-   * @param originType
-   *     <li>1 : MRP
-   *     <li>2 : Sale order
-   *     <li>3 : Other
-   * @return
-   * @throws AxelorException
-   */
+  public enum ManufOrderOriginTypeProduction implements ManufOrderOriginType {
+    ORIGIN_TYPE_MRP,
+    ORIGIN_TYPE_SALE_ORDER,
+    ORIGIN_TYPE_OTHER;
+  }
+
   @Transactional(rollbackOn = {Exception.class})
   public ManufOrder generateManufOrder(
       Product product,
@@ -64,7 +54,7 @@ public interface ManufOrderService {
       BillOfMaterial billOfMaterial,
       LocalDateTime plannedStartDateT,
       LocalDateTime plannedEndDateT,
-      int originType)
+      ManufOrderOriginType manufOrderOriginType)
       throws AxelorException;
 
   public void createToConsumeProdProductList(ManufOrder manufOrder);

--- a/axelor-production/src/main/java/com/axelor/apps/production/service/manuforder/ManufOrderServiceImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/manuforder/ManufOrderServiceImpl.java
@@ -142,7 +142,7 @@ public class ManufOrderServiceImpl implements ManufOrderService {
       BillOfMaterial billOfMaterial,
       LocalDateTime plannedStartDateT,
       LocalDateTime plannedEndDateT,
-      int originType)
+      ManufOrderOriginType manufOrderOrigin)
       throws AxelorException {
 
     if (billOfMaterial == null) {
@@ -168,10 +168,10 @@ public class ManufOrderServiceImpl implements ManufOrderService {
             plannedStartDateT,
             plannedEndDateT);
 
-    if (originType == ORIGIN_TYPE_SALE_ORDER
+    if (manufOrderOrigin.equals(ManufOrderOriginTypeProduction.ORIGIN_TYPE_SALE_ORDER)
             && appProductionService.getAppProduction().getAutoPlanManufOrderFromSO()
-        || originType == ORIGIN_TYPE_MRP
-        || originType == ORIGIN_TYPE_OTHER) {
+        || manufOrderOrigin.equals(ManufOrderOriginTypeProduction.ORIGIN_TYPE_MRP)
+        || manufOrderOrigin.equals(ManufOrderOriginTypeProduction.ORIGIN_TYPE_OTHER)) {
       manufOrder = manufOrderWorkflowService.plan(manufOrder);
     }
 
@@ -895,7 +895,7 @@ public class ManufOrderServiceImpl implements ManufOrderService {
                 childBom,
                 null,
                 manufOrder.getPlannedStartDateT(),
-                ORIGIN_TYPE_OTHER);
+                ManufOrderOriginTypeProduction.ORIGIN_TYPE_OTHER);
 
         moList.add(manufOrder);
         productManufactured.add(childBom.getProduct());

--- a/axelor-production/src/main/java/com/axelor/apps/production/service/productionorder/ProductionOrderSaleOrderServiceImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/productionorder/ProductionOrderSaleOrderServiceImpl.java
@@ -26,7 +26,7 @@ import com.axelor.apps.production.db.ProductionOrder;
 import com.axelor.apps.production.db.repo.ProductionOrderRepository;
 import com.axelor.apps.production.exceptions.IExceptionMessage;
 import com.axelor.apps.production.service.app.AppProductionService;
-import com.axelor.apps.production.service.manuforder.ManufOrderService;
+import com.axelor.apps.production.service.manuforder.ManufOrderService.ManufOrderOriginTypeProduction;
 import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.sale.db.SaleOrderLine;
 import com.axelor.exception.AxelorException;
@@ -34,18 +34,13 @@ import com.axelor.exception.db.repo.TraceBackRepository;
 import com.axelor.i18n.I18n;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
-import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ProductionOrderSaleOrderServiceImpl implements ProductionOrderSaleOrderService {
-
-  private final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   protected UnitConversionService unitConversionService;
   protected ProductionOrderService productionOrderService;
@@ -194,7 +189,7 @@ public class ProductionOrderSaleOrderServiceImpl implements ProductionOrderSaleO
                 null,
                 saleOrder,
                 saleOrderLine,
-                ManufOrderService.ORIGIN_TYPE_SALE_ORDER);
+                ManufOrderOriginTypeProduction.ORIGIN_TYPE_SALE_ORDER);
         tempChildBomList.addAll(
             childBom.getBillOfMaterialSet().stream()
                 .filter(BillOfMaterial::getDefineSubBillOfMaterial)

--- a/axelor-production/src/main/java/com/axelor/apps/production/service/productionorder/ProductionOrderService.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/productionorder/ProductionOrderService.java
@@ -20,6 +20,7 @@ package com.axelor.apps.production.service.productionorder;
 import com.axelor.apps.base.db.Product;
 import com.axelor.apps.production.db.BillOfMaterial;
 import com.axelor.apps.production.db.ProductionOrder;
+import com.axelor.apps.production.service.manuforder.ManufOrderService.ManufOrderOriginType;
 import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.sale.db.SaleOrderLine;
 import com.axelor.exception.AxelorException;
@@ -78,7 +79,7 @@ public interface ProductionOrderService {
       LocalDateTime endDate,
       SaleOrder saleOrder,
       SaleOrderLine saleOrderLine,
-      int originType)
+      ManufOrderOriginType manufOrderOriginType)
       throws AxelorException;
 
   @Transactional(rollbackOn = {Exception.class})

--- a/axelor-production/src/main/java/com/axelor/apps/production/service/productionorder/ProductionOrderServiceImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/productionorder/ProductionOrderServiceImpl.java
@@ -27,6 +27,8 @@ import com.axelor.apps.production.db.repo.ManufOrderRepository;
 import com.axelor.apps.production.db.repo.ProductionOrderRepository;
 import com.axelor.apps.production.exceptions.IExceptionMessage;
 import com.axelor.apps.production.service.manuforder.ManufOrderService;
+import com.axelor.apps.production.service.manuforder.ManufOrderService.ManufOrderOriginType;
+import com.axelor.apps.production.service.manuforder.ManufOrderService.ManufOrderOriginTypeProduction;
 import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.sale.db.SaleOrderLine;
 import com.axelor.exception.AxelorException;
@@ -109,7 +111,7 @@ public class ProductionOrderServiceImpl implements ProductionOrderService {
         null,
         null,
         null,
-        ManufOrderService.ORIGIN_TYPE_OTHER);
+        ManufOrderOriginTypeProduction.ORIGIN_TYPE_OTHER);
 
     return productionOrderRepo.save(productionOrder);
   }
@@ -125,7 +127,7 @@ public class ProductionOrderServiceImpl implements ProductionOrderService {
       LocalDateTime endDate,
       SaleOrder saleOrder,
       SaleOrderLine saleOrderLine,
-      int originType)
+      ManufOrderOriginType manufOrderOriginType)
       throws AxelorException {
 
     ManufOrder manufOrder =
@@ -137,7 +139,7 @@ public class ProductionOrderServiceImpl implements ProductionOrderService {
             billOfMaterial,
             startDate,
             endDate,
-            originType);
+            manufOrderOriginType);
 
     if (manufOrder != null) {
       if (saleOrder != null) {

--- a/axelor-production/src/main/java/com/axelor/apps/production/web/ProductionOrderController.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/web/ProductionOrderController.java
@@ -25,7 +25,7 @@ import com.axelor.apps.production.db.ProductionOrder;
 import com.axelor.apps.production.db.repo.BillOfMaterialRepository;
 import com.axelor.apps.production.db.repo.ProductionOrderRepository;
 import com.axelor.apps.production.exceptions.IExceptionMessage;
-import com.axelor.apps.production.service.manuforder.ManufOrderService;
+import com.axelor.apps.production.service.manuforder.ManufOrderService.ManufOrderOriginTypeProduction;
 import com.axelor.apps.production.service.productionorder.ProductionOrderService;
 import com.axelor.exception.AxelorException;
 import com.axelor.i18n.I18n;
@@ -97,7 +97,7 @@ public class ProductionOrderController {
                 null,
                 productionOrder.getSaleOrder(),
                 null,
-                ManufOrderService.ORIGIN_TYPE_OTHER);
+                ManufOrderOriginTypeProduction.ORIGIN_TYPE_OTHER);
       } else {
         response.setError(I18n.get(IExceptionMessage.MANUF_ORDER_NO_GENERATION));
       }


### PR DESCRIPTION
Signed-off-by: David Trochel <d.trochel@axelor.com>