### PR TITLE
Invoice: fix double payment created when reversing move

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/ReconcileServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/ReconcileServiceImpl.java
@@ -25,6 +25,7 @@ import com.axelor.apps.account.db.MoveLine;
 import com.axelor.apps.account.db.Reconcile;
 import com.axelor.apps.account.db.ReconcileGroup;
 import com.axelor.apps.account.db.repo.InvoicePaymentRepository;
+import com.axelor.apps.account.db.repo.InvoiceRepository;
 import com.axelor.apps.account.db.repo.ReconcileRepository;
 import com.axelor.apps.account.exception.IExceptionMessage;
 import com.axelor.apps.account.service.config.AccountConfigService;
@@ -332,13 +333,14 @@ public class ReconcileServiceImpl implements ReconcileService {
   }
 
   public void updateInvoicePayments(Reconcile reconcile) throws AxelorException {
+    InvoiceRepository invoiceRepository = Beans.get(InvoiceRepository.class);
 
     MoveLine debitMoveLine = reconcile.getDebitMoveLine();
     MoveLine creditMoveLine = reconcile.getCreditMoveLine();
     Move debitMove = debitMoveLine.getMove();
     Move creditMove = creditMoveLine.getMove();
-    Invoice debitInvoice = debitMove.getInvoice();
-    Invoice creditInvoice = creditMove.getInvoice();
+    Invoice debitInvoice = invoiceRepository.findByMove(debitMove);
+    Invoice creditInvoice = invoiceRepository.findByMove(creditMove);
     BigDecimal amount = reconcile.getAmount();
 
     if (debitInvoice != null

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveReverseServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveReverseServiceImpl.java
@@ -72,8 +72,8 @@ public class MoveReverseServiceImpl implements MoveReverseService {
             move.getAutoYearClosureMove(),
             move.getOrigin(),
             move.getDescription(),
-            move.getInvoice(),
-            move.getPaymentVoucher());
+            null,
+            null);
 
     boolean validatedMove =
         move.getStatusSelect() == MoveRepository.STATUS_ACCOUNTED
@@ -81,7 +81,7 @@ public class MoveReverseServiceImpl implements MoveReverseService {
 
     for (MoveLine moveLine : move.getMoveLineList()) {
       log.debug("Moveline {}", moveLine);
-      Boolean isDebit = moveLine.getDebit().compareTo(BigDecimal.ZERO) > 0;
+      boolean isDebit = moveLine.getDebit().compareTo(BigDecimal.ZERO) > 0;
 
       MoveLine newMoveLine = generateReverseMoveLine(newMove, moveLine, dateOfReversion, isDebit);
 
@@ -96,8 +96,7 @@ public class MoveReverseServiceImpl implements MoveReverseService {
                     AnalyticMoveLineRepository.STATUS_REAL_ACCOUNTING,
                     dateOfReversion);
         if (CollectionUtils.isNotEmpty(analyticMoveLineList)) {
-          analyticMoveLineList.forEach(
-              analyticMoveLine -> newMoveLine.addAnalyticMoveLineListItem(analyticMoveLine));
+          analyticMoveLineList.forEach(newMoveLine::addAnalyticMoveLineListItem);
         }
       }
 

--- a/axelor-account/src/main/resources/domains/Invoice.xml
+++ b/axelor-account/src/main/resources/domains/Invoice.xml
@@ -215,6 +215,8 @@
 
     <unique-constraint columns="invoiceId,company"/>
 
+    <finder-method name="findByMove" using="move"/>
+
     <extra-code><![CDATA[
 
 	   	static final int NONE = 0;


### PR DESCRIPTION
- When reconciling and generating invoice payment, to find the related
  invoice we do not find the invoice in the move, but instead we fetch
  the invoice linking to the move.
- Do not copy the link to invoice and payment voucher when reversing a
  move.
RM45877