### PR TITLE
Anomaly #47871: StockLocation grid view print button does not work

### DIFF
--- a/axelor-stock/src/main/resources/views/StockLocation.xml
+++ b/axelor-stock/src/main/resources/views/StockLocation.xml
@@ -7,7 +7,7 @@
     model="com.axelor.apps.stock.db.StockLocation">
     <toolbar>
       <button name="printBtn" title="Print" icon="fa-print"
-        onClick="save,action-stock-location-method-open-print-wizard"/>
+        onClick="action-stock-location-method-open-print-wizard"/>
     </toolbar>
     <field name="name"/>
     <field name="parentStockLocation" form-view="stock-location-form"

--- a/changelogs/unreleased/47871-fix-print-grid-stock-location.yml
+++ b/changelogs/unreleased/47871-fix-print-grid-stock-location.yml
@@ -1,0 +1,8 @@
+---
+title: fix print button on StockLocation grid view not working
+type: fix
+description: |
+  When pushing print button on stock location grid view, linked action did not open the print wizard
+  
+  Corrected problem and made the button work again
+  When pushing print button on stock location grid view, you can now print the selected locations.


### PR DESCRIPTION
Anomaly RM#47871: Corrected print button not working on StockLocation grid view by removing useless save action