### PR TITLE
RM#49970: corrected stockMove birt report by grouping qty per product

### DIFF
--- a/axelor-stock/src/main/resources/reports/StockMove.rptdesign
+++ b/axelor-stock/src/main/resources/reports/StockMove.rptdesign
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <report xmlns="http://www.eclipse.org/birt/2005/design" version="3.2.23" id="1">
-    <property name="createdBy">Eclipse BIRT Designer Version 4.7.0.v201706222054</property>
+    <property name="createdBy">Eclipse BIRT Designer Version 4.8.0.v201806261756</property>
     <list-property name="propertyBindings">
         <structure>
             <property name="name">odaURL</property>
@@ -40,9 +40,6 @@ reportContext.getDesignHandle().findMasterPage("Simple MasterPage").setProperty(
             <property name="isRequired">true</property>
             <property name="dataType">decimal</property>
             <property name="distinct">true</property>
-            <simple-property-list name="defaultValue">
-                <value type="constant">1</value>
-            </simple-property-list>
             <list-property name="selectionList"/>
             <property name="paramType">simple</property>
             <property name="concealValue">false</property>
@@ -168,9 +165,6 @@ reportContext.getDesignHandle().findMasterPage("Simple MasterPage").setProperty(
             <property name="isRequired">false</property>
             <property name="dataType">boolean</property>
             <property name="distinct">true</property>
-            <simple-property-list name="defaultValue">
-                <value type="constant">False</value>
-            </simple-property-list>
             <list-property name="selectionList"/>
             <property name="paramType">simple</property>
             <property name="controlType">check-box</property>
@@ -3553,6 +3547,9 @@ row["first_name"]
                             <structure>
                                 <property name="name">total_qty_per_product</property>
                                 <property name="dataType">float</property>
+                                <simple-property-list name="aggregateOn">
+                                    <value>ProductGroup</value>
+                                </simple-property-list>
                                 <property name="aggregateFunction">SUM</property>
                                 <list-property name="arguments">
                                     <structure>

--- a/changelogs/unreleased/49970.yml
+++ b/changelogs/unreleased/49970.yml
@@ -1,0 +1,12 @@
+---
+title: Quantity is the same for all products in internal stock movement print
+type: fix
+desscription: |
+  When option "Display line details on printing" in stock configuration, 
+  identical products are regrouped in the printed file.
+  Instead of summing identical products, 
+  the application makes the sum of all products and allocate this number to 
+  the quantity of each product.
+  
+  Corrected birt report to get rid of the anomaly.
+  Quantity is now displayed correctly by product type. 


### PR DESCRIPTION
When option "Display line details on printing" in stock configuration, identical products are regrouped in the printed file.
Instead of summing identical products, the application makes the sum of all products and allocate this number to the quantity of each product.

Corrected birt report and displaying quantity per product type. 