### PR TITLE
Invoice: fixed advance payment on invoice

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveToolService.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveToolService.java
@@ -64,9 +64,8 @@ public interface MoveToolService {
    *
    * @param invoicePayment Invoice payment
    * @return
-   * @throws AxelorException
    */
-  List<MoveLine> getInvoiceCustomerMoveLines(InvoicePayment invoicePayment) throws AxelorException;
+  List<MoveLine> getInvoiceCustomerMoveLines(InvoicePayment invoicePayment);
 
   /**
    * Method that returns all the move lines of an invoice that are not completely lettered

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveToolServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveToolServiceImpl.java
@@ -48,7 +48,6 @@ import com.axelor.exception.AxelorException;
 import com.axelor.exception.db.repo.TraceBackRepository;
 import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
-import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import java.lang.invoke.MethodHandles;
@@ -166,12 +165,12 @@ public class MoveToolServiceImpl implements MoveToolService {
    * @throws AxelorException
    */
   @Override
-  public List<MoveLine> getInvoiceCustomerMoveLines(InvoicePayment invoicePayment)
-      throws AxelorException {
-    List<MoveLine> moveLines = Lists.newArrayList();
+  public List<MoveLine> getInvoiceCustomerMoveLines(InvoicePayment invoicePayment) {
+    List<MoveLine> moveLines = new ArrayList<>();
     if (!CollectionUtils.isEmpty(invoicePayment.getInvoiceTermPaymentList())) {
       for (InvoiceTermPayment invoiceTermPayment : invoicePayment.getInvoiceTermPaymentList()) {
-        if (!moveLines.contains(invoiceTermPayment.getInvoiceTerm().getMoveLine())) {
+        if (invoiceTermPayment.getInvoiceTerm().getMoveLine() != null
+            && !moveLines.contains(invoiceTermPayment.getInvoiceTerm().getMoveLine())) {
           moveLines.add(invoiceTermPayment.getInvoiceTerm().getMoveLine());
         }
       }

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/payment/invoice/payment/InvoicePaymentValidateServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/payment/invoice/payment/InvoicePaymentValidateServiceImpl.java
@@ -79,6 +79,7 @@ public class InvoicePaymentValidateServiceImpl implements InvoicePaymentValidate
   protected ReconcileService reconcileService;
   protected AppAccountService appAccountService;
   protected AccountManagementAccountService accountManagementAccountService;
+  protected InvoicePaymentToolService invoicePaymentToolService;
 
   @Inject
   public InvoicePaymentValidateServiceImpl(
@@ -91,7 +92,8 @@ public class InvoicePaymentValidateServiceImpl implements InvoicePaymentValidate
       InvoicePaymentRepository invoicePaymentRepository,
       ReconcileService reconcileService,
       AppAccountService appAccountService,
-      AccountManagementAccountService accountManagementAccountService) {
+      AccountManagementAccountService accountManagementAccountService,
+      InvoicePaymentToolService invoicePaymentToolService) {
 
     this.paymentModeService = paymentModeService;
     this.moveLineCreateService = moveLineCreateService;
@@ -103,6 +105,7 @@ public class InvoicePaymentValidateServiceImpl implements InvoicePaymentValidate
     this.reconcileService = reconcileService;
     this.appAccountService = appAccountService;
     this.accountManagementAccountService = accountManagementAccountService;
+    this.invoicePaymentToolService = invoicePaymentToolService;
   }
 
   /**
@@ -132,6 +135,7 @@ public class InvoicePaymentValidateServiceImpl implements InvoicePaymentValidate
 
     setInvoicePaymentStatus(invoicePayment);
     createInvoicePaymentMove(invoicePayment);
+    invoicePaymentToolService.updateAmountPaid(invoicePayment.getInvoice());
 
     if (invoicePayment.getInvoice() != null
         && invoicePayment.getInvoice().getOperationSubTypeSelect()
@@ -246,16 +250,23 @@ public class InvoicePaymentValidateServiceImpl implements InvoicePaymentValidate
     MoveLine customerMoveLine = null;
     move.setTradingName(invoice.getTradingName());
 
-    BigDecimal maxAmount =
-        invoiceMoveLines.stream()
-            .map(MoveLine::getAmountRemaining)
-            .reduce(BigDecimal::add)
-            .orElse(BigDecimal.ZERO);
+    BigDecimal maxAmount;
+    if (CollectionUtils.isEmpty(invoiceMoveLines)) {
+      // using null value to indicate we do not use a maxAmount
+      maxAmount = null;
+    } else {
+      maxAmount =
+          invoiceMoveLines.stream()
+              .map(MoveLine::getAmountRemaining)
+              .reduce(BigDecimal::add)
+              .orElse(BigDecimal.ZERO);
+    }
+
     move = this.fillMove(invoicePayment, move, customerAccount, maxAmount);
     moveValidateService.accounting(move);
 
     for (MoveLine moveline : move.getMoveLineList()) {
-      if (moveline.getAccount() == customerAccount) {
+      if (customerAccount.equals(moveline.getAccount())) {
         customerMoveLine = moveline;
       }
     }
@@ -336,8 +347,10 @@ public class InvoicePaymentValidateServiceImpl implements InvoicePaymentValidate
         invoicePayment.getInvoiceTermPaymentList().stream()
             .map(InvoiceTermPayment::getCompanyPaidAmount)
             .reduce(BigDecimal::add)
-            .orElse(BigDecimal.ZERO)
-            .min(maxAmount);
+            .orElse(BigDecimal.ZERO);
+    if (maxAmount != null) {
+      companyPaymentAmount = companyPaymentAmount.min(maxAmount);
+    }
     BigDecimal currencyRate = companyPaymentAmount.divide(paymentAmount, 5, RoundingMode.HALF_UP);
 
     move.addMoveLineListItem(

--- a/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/service/invoice/payment/InvoicePaymentValidateServiceBankPayImpl.java
+++ b/axelor-bank-payment/src/main/java/com/axelor/apps/bankpayment/service/invoice/payment/InvoicePaymentValidateServiceBankPayImpl.java
@@ -57,7 +57,6 @@ public class InvoicePaymentValidateServiceBankPayImpl extends InvoicePaymentVali
   protected BankOrderCreateService bankOrderCreateService;
   protected BankOrderService bankOrderService;
   protected InvoiceTermService invoiceTermService;
-  protected InvoicePaymentToolService invoicePaymentToolService;
 
   @Inject
   public InvoicePaymentValidateServiceBankPayImpl(
@@ -85,11 +84,11 @@ public class InvoicePaymentValidateServiceBankPayImpl extends InvoicePaymentVali
         invoicePaymentRepository,
         reconcileService,
         appAccountService,
-        accountManagementAccountService);
+        accountManagementAccountService,
+        invoicePaymentToolService);
     this.bankOrderCreateService = bankOrderCreateService;
     this.bankOrderService = bankOrderService;
     this.invoiceTermService = invoiceTermService;
-    this.invoicePaymentToolService = invoicePaymentToolService;
   }
 
   @Override


### PR DESCRIPTION
It was previously impossible to pay an advance payment invoice due to 6.4 changes. This commit correctly manages the case where an invoice payment is missing a move from the invoice.
RM52775