### PR TITLE
Feature #60177 Update checkPreconditions process on Move service 

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/exception/AccountExceptionMessage.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/exception/AccountExceptionMessage.java
@@ -317,6 +317,8 @@ public final class AccountExceptionMessage {
       "Accounting move can not be accounted because its fiscal period is closed." /*)*/;
   public static final String MOVE_12 = /*$$(*/
       "The currency is missing on the account move %s" /*)*/;
+  public static final String MOVE_13 = /*$$(*/
+      "An incoherence has been detected between the date and origin date of the move %s and the corresponding dates of its move lines. Those dates must be same." /*)*/;
   public static final String MOVE_VALIDATION_FISCAL_PERIOD_CLOSED = /*$$(*/
       "Accounting move can not be validated because its fiscal period is closed." /*)*/;
   public static final String MOVE_PARTNER_IS_NOT_COMPATIBLE_WITH_SELECTED_JOURNAL = /*$$(*/

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveValidateServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveValidateServiceImpl.java
@@ -205,6 +205,19 @@ public class MoveValidateServiceImpl implements MoveValidateService {
           move.getReference());
     }
 
+    if (move.getMoveLineList().stream()
+        .anyMatch(
+            moveLine ->
+                moveLine.getDate() == null
+                    || moveLine.getOriginDate() == null
+                    || moveLine.getDate().compareTo(move.getDate()) != 0
+                    || moveLine.getOriginDate().compareTo(move.getOriginDate()) != 0)) {
+      throw new AxelorException(
+          TraceBackRepository.CATEGORY_INCONSISTENCY,
+          I18n.get(AccountExceptionMessage.MOVE_13),
+          move.getReference());
+    }
+
     checkClosurePeriod(move);
     checkInactiveAnalyticJournal(move);
     checkInactiveAccount(move);

--- a/changelogs/unreleased/fix-prevent-move-line-from-having-different-date-than-move.yml
+++ b/changelogs/unreleased/fix-prevent-move-line-from-having-different-date-than-move.yml
@@ -1,0 +1,3 @@
+---
+title: "Moves : On check preconditions for any move process, prevent it's move lines from having a different date/origin date than itself."
+type: fix


### PR DESCRIPTION
Update checkPreconditions process on Move service to prevent move line having different date than the linked move
Feature #60177 