### PR TITLE
Feature RM#62489 :Helpdesk:Ticket: Define a fullname namecolumn

### DIFF
--- a/axelor-helpdesk/src/main/resources/domains/Ticket.xml
+++ b/axelor-helpdesk/src/main/resources/domains/Ticket.xml
@@ -9,6 +9,14 @@
 
     <string name="ticketSeq" title="Ticket Number" readonly="true"/>
     <string name="subject" title="Subject" required="true"/>
+    <string name="fullName" title="Full name" namecolumn="true" search="ticketSeq,subject">
+    <![CDATA[
+    	String fullName = "";
+    	if(ticketSeq != null){
+    		fullName = ticketSeq + " - ";
+    	}
+    	return fullName + subject;
+    ]]></string>
     <many-to-one name="project" ref="com.axelor.apps.project.db.Project" title="Project"/>
     <many-to-one name="customer" ref="com.axelor.apps.base.db.Partner" title="Customer"/>
     <many-to-one name="contactPartner" ref="com.axelor.apps.base.db.Partner"

--- a/changelogs/unreleased/Feature-define-a-fullname-namecolumn.yml
+++ b/changelogs/unreleased/Feature-define-a-fullname-namecolumn.yml
@@ -1,0 +1,3 @@
+---
+title: "Axelor Helpdesk : Added a new field fullName to the ticket which will be used as namecolumn"
+type: feature


### PR DESCRIPTION
Added a new field fullName to the ticket which will be used as namecolumn.