### PR TITLE
RM#63864 Replaced deleted action by existing one

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/record/MoveDefaultServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/record/MoveDefaultServiceImpl.java
@@ -25,7 +25,6 @@ import com.axelor.apps.base.db.repo.CompanyRepository;
 import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.user.UserService;
 import com.google.inject.Inject;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/record/MoveDefaultServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/record/MoveDefaultServiceImpl.java
@@ -25,6 +25,7 @@ import com.axelor.apps.base.db.repo.CompanyRepository;
 import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.user.UserService;
 import com.google.inject.Inject;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -97,7 +98,7 @@ public class MoveDefaultServiceImpl implements MoveDefaultService {
 
     Company company = move.getCompany();
 
-    if (company != null && company.getCurrency() != null) {
+    if (move.getPartner() == null && company != null && company.getCurrency() != null) {
       move.setCompanyCurrency(company.getCurrency());
       move.setCurrency(company.getCurrency());
       move.setCurrencyCode(company.getCurrency().getCodeISO());

--- a/axelor-account/src/main/resources/views/Move.xml
+++ b/axelor-account/src/main/resources/views/Move.xml
@@ -110,7 +110,7 @@
             form-view="fiscal-position-form" grid-view="fiscal-position-grid"/>
           <field name="currency"
             readonlyIf="$validatePeriod || moveLineList.length &gt; 0 || statusSelect == 3"
-            colSpan="2" onChange="action-move-record-set-currency-code" required="true"/>
+            colSpan="2" onChange="action-move-method-set-default-move-currency" required="true"/>
           <field name="paymentMode"
             readonlyIf="period.statusSelect == 2 || period.statusSelect == 5 || $validatePeriod"
             colSpan="3" onChange="action-move-group-payment-mode-onchange"

--- a/changelogs/unreleased/63864.yaml
+++ b/changelogs/unreleased/63864.yaml
@@ -1,6 +1,5 @@
-title: Replaced lost action by a an existing one
+title: Replaced deleted action by a an existing one
 type: fix
 description:
-  Replaced on field 'currency' in 'onChange' attribute "action-move-record-set-currency-code" by "action-move-method-set-default-move-currency".
-  Modify 'setDefaultCurrency' in 'MoveDefaultServiceImpl' by adding 'move.getPartner() == null' in if condition, so now when a company is chosen and a partner exist, we don't override
-  the partner currency by the company currency.
+  On move form when we select a currency automatically chose the one from partner,
+  if the partner is null then select the currency from the company.

--- a/changelogs/unreleased/63864.yaml
+++ b/changelogs/unreleased/63864.yaml
@@ -1,0 +1,6 @@
+title: Replaced lost action by a an existing
+type: fix
+description:
+  Replaced on field 'currency' in 'onChange' attribute "action-move-record-set-currency-code" by "action-move-method-set-default-move-currency".
+  Modify 'setDefaultCurrency' in 'MoveDefaultServiceImpl' by adding 'move.getPartner() == null' in if condition, so now when a company is chosen and a partner exist, we don't override
+  the partner currency by the company currency.

--- a/changelogs/unreleased/63864.yaml
+++ b/changelogs/unreleased/63864.yaml
@@ -1,4 +1,4 @@
-title: Replaced lost action by a an existing
+title: Replaced lost action by a an existing one
 type: fix
 description:
   Replaced on field 'currency' in 'onChange' attribute "action-move-record-set-currency-code" by "action-move-method-set-default-move-currency".


### PR DESCRIPTION
Replaced on field 'currency' in 'onChange' attribute "action-move-record-set-currency-code" by "action-move-method-set-default-move-currency". Modify 'setDefaultCurrency' in 'MoveDefaultServiceImpl' by adding 'move.getPartner() == null' in if condition, so now when a company is chosen and a partner exist, we don't override the partner currency by the company currency.