### PR TITLE
RM#54428 Added filter on tracking number when adding consumed and pro…

### DIFF
--- a/axelor-production/src/main/resources/views/StockMoveLine.xml
+++ b/axelor-production/src/main/resources/views/StockMoveLine.xml
@@ -94,7 +94,8 @@
       <field name="unitPriceTaxed" hidden="true"/>
       <field name="unit" canEdit="false" form-view="unit-form" grid-view="unit-grid"/>
       <field name="trackingNumber" onChange="action-stock-move-line-record-product"
-        form-view="tracking-number-form" grid-view="tracking-number-grid"
+        domain="self.product = :product" form-view="tracking-number-form"
+        grid-view="tracking-number-grid"
         canNew="$get('stockMove.fromStockLocation.typeSelect') == 3 &amp;&amp; ($get('stockMove.toStockLocation.typeSelect') == 1 || $get('stockMove.toStockLocation.typeSelect') == 2)"
         onSelect="action-stock-move-line-attrs-tracking-number-domain"
         readonlyIf="$get('stockMove.statusSelect') > 2"

--- a/changelogs/unreleased/54428.yaml
+++ b/changelogs/unreleased/54428.yaml
@@ -1,0 +1,7 @@
+title: Added filter on tracking number when adding consumed and produced products of ManufOrder
+type: fix
+description:
+  When trying to add a new consumed product or produced product on a ManufOrder, there is now a filter on the trackingNumber field.
+  We can select a tracking numbers depending of the selected product, if the product has at least one tracking number.
+
+  


### PR DESCRIPTION
…duced products of ManufOrder

When trying to add a new consumed product (consumedStockMoveLineList) or produced product (producedStockMoveLineList) on a ManufOrder, after selecting the product in the view form (stock-move-line-production-form), there is now a filter on the trackingNumber field.