### PR TITLE
RM#64108 Correct NPE when selecting partner and Company is empty

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveViewHelperServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveViewHelperServiceImpl.java
@@ -29,19 +29,22 @@ public class MoveViewHelperServiceImpl implements MoveViewHelperService {
 
   @Override
   public String filterPartner(Company company, Journal journal) {
-    Long companyId = company.getId();
-    String domain = "self.isContact = false AND " + companyId + " member of self.companySet";
-    if (journal != null && !Strings.isNullOrEmpty(journal.getCompatiblePartnerTypeSelect())) {
-      domain += " AND (";
-      String[] partnerSet = journal.getCompatiblePartnerTypeSelect().split(", ");
-      String lastPartner = partnerSet[partnerSet.length - 1];
-      for (String partner : partnerSet) {
-        domain += "self." + partner + " = true";
-        if (!partner.equals(lastPartner)) {
-          domain += " OR ";
+    String domain = "self.isContact = false";
+    if (company != null) {
+      Long companyId = company.getId();
+      domain = " AND " + companyId + " member of self.companySet";
+      if (journal != null && !Strings.isNullOrEmpty(journal.getCompatiblePartnerTypeSelect())) {
+        domain += " AND (";
+        String[] partnerSet = journal.getCompatiblePartnerTypeSelect().split(", ");
+        String lastPartner = partnerSet[partnerSet.length - 1];
+        for (String partner : partnerSet) {
+          domain += "self." + partner + " = true";
+          if (!partner.equals(lastPartner)) {
+            domain += " OR ";
+          }
         }
+        domain += ")";
       }
-      domain += ")";
     }
     return domain;
   }

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveViewHelperServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveViewHelperServiceImpl.java
@@ -31,7 +31,6 @@ public class MoveViewHelperServiceImpl implements MoveViewHelperService {
   public String filterPartner(Company company, Journal journal) {
     String domain = "self.isContact = false";
     if (company != null) {
-      Long companyId = company.getId();
       domain += " AND " + company.getId() + " member of self.companySet";
       if (journal != null && !Strings.isNullOrEmpty(journal.getCompatiblePartnerTypeSelect())) {
         domain += " AND (";

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveViewHelperServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveViewHelperServiceImpl.java
@@ -32,7 +32,7 @@ public class MoveViewHelperServiceImpl implements MoveViewHelperService {
     String domain = "self.isContact = false";
     if (company != null) {
       Long companyId = company.getId();
-      domain = " AND " + companyId + " member of self.companySet";
+      domain += " AND " + company.getId() + " member of self.companySet";
       if (journal != null && !Strings.isNullOrEmpty(journal.getCompatiblePartnerTypeSelect())) {
         domain += " AND (";
         String[] partnerSet = journal.getCompatiblePartnerTypeSelect().split(", ");

--- a/changelogs/unreleased/64108.yaml
+++ b/changelogs/unreleased/64108.yaml
@@ -1,0 +1,5 @@
+title: NPE when selecting partner and Company is empty
+type: fix
+description:
+  When creating an account move, when you select a partner and filter the partners by the company,
+  we check that the company is not null.


### PR DESCRIPTION
When creating an account move, when you select a partner and filter the partners by the company, we check that the company is not null. Added a condition in filterPartner method in MoveViewHelperServiceImpl.