### PR TITLE
RM#64151 When activating autoUpdateSalePrice option on Product update…

### DIFF
--- a/axelor-base/src/main/resources/views/Product.xml
+++ b/axelor-base/src/main/resources/views/Product.xml
@@ -205,7 +205,8 @@
             showIf="sellable" canNew="false" canSelect="true"/>
           <field name="productSynchronizedInPrestashop" colSpan="6"
             if="__config__.app.isApp('prestashop')" if-module="axelor-prestashop"/>
-          <field name="autoUpdateSalePrice" hideIf="!sellable" colSpan="12"/>
+          <field name="autoUpdateSalePrice" hideIf="!sellable" colSpan="12"
+            onChange="action-product-record-compute-sale-price"/>
           <field name="salePrice" readonlyIf="autoUpdateSalePrice" hideIf="!sellable"
             colSpan="12"/>
           <field name="saleCurrency" canEdit="false" hideIf="!sellable" colSpan="12"

--- a/changelogs/unreleased/64151.yaml
+++ b/changelogs/unreleased/64151.yaml
@@ -1,0 +1,5 @@
+title: When activating autoUpdateSalePrice option on Product update salePrice
+type: fix
+description:
+  On product-form, the sale price can be computed from costPrice and managPriceCoef when autoUpdateSalePrice field is true.
+  The action is now triggered when activating the autoUpdateSalePrice option too.


### PR DESCRIPTION
… salePrice

On product-form, the sale price can be computed from costPrice and managPriceCoef when autoUpdateSalePrice field is true. The action "action-product-record-compute-sale-price" is now triggered also when activating the autoUpdateSalePrice option.