### PR TITLE
RM#64349 Some products are now selectable in sale order line

### DIFF
--- a/axelor-sale/src/main/java/com/axelor/apps/sale/service/saleorder/SaleOrderLineServiceImpl.java
+++ b/axelor-sale/src/main/java/com/axelor/apps/sale/service/saleorder/SaleOrderLineServiceImpl.java
@@ -984,7 +984,7 @@ public class SaleOrderLineServiceImpl implements SaleOrderLineService {
     // But here, we have to do this because overriding a sale service in hr module will prevent the
     // override in supplychain, business-project, and business production module.
     if (ModuleManager.isInstalled("axelor-human-resource")) {
-      domain += " AND self.expense = false ";
+      domain += " AND self.expense = false OR self.expense IS NULL";
     }
 
     return domain;

--- a/changelogs/unreleased/64349.yaml
+++ b/changelogs/unreleased/64349.yaml
@@ -1,0 +1,4 @@
+title: Some products are not selectable in sale order line
+type: fix
+description:
+  If a product has field 'expense' as null product can still be selectable in a sale order line.


### PR DESCRIPTION
If a product has field 'expense' as null product can still be selectable in a sale order line. We did it by adding a clause in the domain 'OR self.expense IS NULL'.