### PR TITLE
RM#63677 Fill dueDate when generating moves automatically

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveCreateFromInvoiceServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/MoveCreateFromInvoiceServiceImpl.java
@@ -159,6 +159,10 @@ public class MoveCreateFromInvoiceServiceImpl implements MoveCreateFromInvoiceSe
         move.setTradingName(invoice.getTradingName());
         move.setPaymentCondition(invoice.getPaymentCondition());
 
+        if (move.getPaymentCondition() != null) {
+          move.setDueDate(invoice.getDueDate());
+        }
+
         boolean isDebitCustomer = moveToolService.isDebitCustomer(invoice, false);
 
         move.getMoveLineList()

--- a/changelogs/unreleased/63677.yaml
+++ b/changelogs/unreleased/63677.yaml
@@ -1,0 +1,4 @@
+title: Fill dueDate when generating moves automatically
+type: fix
+description:
+  Fill dueDate when generating moves automatically (when ventilating an invoice), fill dueDate when there is a paymentCondition filled.


### PR DESCRIPTION
Fill dueDate when generating moves automatically by adding a condition on 'createMove' in 'MoveCreateFromInvoiceServiceImpl'.