### PR TITLE
RM#65837 Fix on conversion on statusSelect CRM 7.1

### DIFF
--- a/axelor-crm/src/main/resources/views/Lead.xml
+++ b/axelor-crm/src/main/resources/views/Lead.xml
@@ -283,8 +283,7 @@
       <button name="grabLeadBtn" title="Take in charge" hideIf="user.id == _internalUserId"
         icon="fa-suitcase" onClick="save,action-lead-method-assign-to-me"/>
       <button name="convertBtn" title="Convert" hideIf="!id || isConverted"
-        icon="fa-exchange"
-        onClick="save,action-lead-method-view-lead-with-same-domain-name,action-lead-view-convert-lead"/>
+        icon="fa-exchange" onClick="action-group-crm-convert"/>
       <button name="showPartnerBtn" title="Show Partner" showIf="partner" colSpan="6"
         onClick="action-lead-view-show-partner"/>
     </panel>
@@ -395,6 +394,8 @@
       if="eval: __this__?.leadStatus?.id == __config__.app.getApp('crm')?.lostLeadStatus?.id"/>
     <action name="action-lead-record-clear-lost-reason"
       if="eval: __this__?.leadStatus?.id != __config__.app.getApp('crm')?.lostLeadStatus?.id"/>
+    <action name="action-group-crm-convert"
+      if="eval: __this__?.leadStatus?.id == __config__.app.getApp('crm')?.convertedLeadStatus?.id"/>
   </action-group>
 
   <action-group name="action-group-crm-lead-onnew">
@@ -406,6 +407,12 @@
     <action name="action-lead-method-set-social-network-url"/>
     <action name="action-crm-lead-method-check-name"/>
     <action name="action-lead-attrs-display-lost-reason"/>
+  </action-group>
+
+  <action-group name="action-group-crm-convert">
+    <action name="save"/>
+    <action name="action-lead-method-view-lead-with-same-domain-name"/>
+    <action name="action-lead-view-convert-lead"/>
   </action-group>
 
   <action-attrs name="action-lead-attrs-display-lost-reason">

--- a/axelor-crm/src/main/resources/views/Lead.xml
+++ b/axelor-crm/src/main/resources/views/Lead.xml
@@ -283,7 +283,7 @@
       <button name="grabLeadBtn" title="Take in charge" hideIf="user.id == _internalUserId"
         icon="fa-suitcase" onClick="save,action-lead-method-assign-to-me"/>
       <button name="convertBtn" title="Convert" hideIf="!id || isConverted"
-        icon="fa-exchange" onClick="action-group-crm-convert"/>
+        icon="fa-exchange" onClick="action-lead-group-lead-convert"/>
       <button name="showPartnerBtn" title="Show Partner" showIf="partner" colSpan="6"
         onClick="action-lead-view-show-partner"/>
     </panel>
@@ -394,8 +394,14 @@
       if="eval: __this__?.leadStatus?.id == __config__.app.getApp('crm')?.lostLeadStatus?.id"/>
     <action name="action-lead-record-clear-lost-reason"
       if="eval: __this__?.leadStatus?.id != __config__.app.getApp('crm')?.lostLeadStatus?.id"/>
-    <action name="action-group-crm-convert"
+    <action name="action-lead-group-lead-convert"
       if="eval: __this__?.leadStatus?.id == __config__.app.getApp('crm')?.convertedLeadStatus?.id"/>
+  </action-group>
+
+  <action-group name="action-lead-group-lead-convert">
+    <action name="save"/>
+    <action name="action-lead-method-view-lead-with-same-domain-name"/>
+    <action name="action-lead-view-convert-lead"/>
   </action-group>
 
   <action-group name="action-group-crm-lead-onnew">
@@ -407,12 +413,6 @@
     <action name="action-lead-method-set-social-network-url"/>
     <action name="action-crm-lead-method-check-name"/>
     <action name="action-lead-attrs-display-lost-reason"/>
-  </action-group>
-
-  <action-group name="action-group-crm-convert">
-    <action name="save"/>
-    <action name="action-lead-method-view-lead-with-same-domain-name"/>
-    <action name="action-lead-view-convert-lead"/>
   </action-group>
 
   <action-attrs name="action-lead-attrs-display-lost-reason">


### PR DESCRIPTION
In lead, when clicking on status equal to appCRM.convertedLeadStatus, call same process as convert button.