### PR TITLE
RM#66691 FinancialDiscount in invoice - fields related to financial discount are displayed even when option disabled on AppAccount

### DIFF
--- a/axelor-account/src/main/resources/views/Invoice.xml
+++ b/axelor-account/src/main/resources/views/Invoice.xml
@@ -809,7 +809,8 @@ InvoiceSet.length > 0))"
             <viewer><![CDATA[{{record.reasonOfRefusalToPayStr}}]]></viewer>
           </field>
         </panel>
-        <panel name="financialDiscountPanel" showIf="statusSelect > 2" colSpan="12" if="__config__.app.getApp('account')?.getManageFinancialDiscount()">
+        <panel name="financialDiscountPanel" showIf="statusSelect > 2" colSpan="12"
+          if="__config__.app.getApp('account')?.getManageFinancialDiscount()">
           <field name="financialDiscount" readonlyIf="amountPaid > 0"
             onChange="action-invoice-group-financial-discount"/>
           <field name="financialDiscountDeadlineDate" readonly="true"

--- a/axelor-account/src/main/resources/views/Invoice.xml
+++ b/axelor-account/src/main/resources/views/Invoice.xml
@@ -809,7 +809,7 @@ InvoiceSet.length > 0))"
             <viewer><![CDATA[{{record.reasonOfRefusalToPayStr}}]]></viewer>
           </field>
         </panel>
-        <panel name="financialDiscountPanel" showIf="statusSelect > 2" colSpan="12">
+        <panel name="financialDiscountPanel" showIf="statusSelect > 2" colSpan="12" if="__config__.app.getApp('account')?.getManageFinancialDiscount()">
           <field name="financialDiscount" readonlyIf="amountPaid > 0"
             onChange="action-invoice-group-financial-discount"/>
           <field name="financialDiscountDeadlineDate" readonly="true"

--- a/changelogs/unreleased/66691.yaml
+++ b/changelogs/unreleased/66691.yaml
@@ -1,0 +1,3 @@
+---
+title: FinancialDiscount in invoice - fields related to financial discount are displayed even when option disabled on AppAccount
+type: fix


### PR DESCRIPTION
Add condition on 'FinancialDiscountPanel' to hide it if 'Manage financial discount' is disabled.