### PR TITLE
Remove warning when reloading view

### DIFF
--- a/axelor-base/src/main/resources/views/MetaMenu.xml
+++ b/axelor-base/src/main/resources/views/MetaMenu.xml
@@ -21,10 +21,6 @@
       <attribute name="massUpdate" value="true"/>
     </extend>
 
-    <extend target="//field[@name='top']">
-      <attribute name="massUpdate" value="true"/>
-    </extend>
-
     <extend target="//field[@name='left']">
       <attribute name="massUpdate" value="true"/>
     </extend>


### PR DESCRIPTION
Field "top" does not exist anymore in meta menu, as it was removed in AOP v7.

RM71265