### PR TITLE
Invoice: fill deliveryAddressStr on advance payment invoice

### DIFF
--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/SaleOrderInvoiceServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/SaleOrderInvoiceServiceImpl.java
@@ -337,6 +337,7 @@ public class SaleOrderInvoiceServiceImpl implements SaleOrderInvoiceService {
     invoiceGenerator.populate(invoice, invoiceLinesList);
 
     invoice.setAddressStr(saleOrder.getMainInvoicingAddressStr());
+    invoice.setDeliveryAddressStr(saleOrder.getDeliveryAddressStr());
 
     invoice.setOperationSubTypeSelect(operationSubTypeSelect);
 

--- a/changelogs/unreleased/75696-fix-delivery-address-on-advance-payment-invoice-printings.yml
+++ b/changelogs/unreleased/75696-fix-delivery-address-on-advance-payment-invoice-printings.yml
@@ -1,0 +1,3 @@
+---
+title: "Invoice: fixed display of delivery address on advance payment invoices generated from a sale order."
+type: fix


### PR DESCRIPTION
During the generation of advance payment invoice from a sale order, deliveryAddressStr is now filled.

RM75696