### PR TITLE
76327 PAYMENTSESSION / BANKORDER : Correct anomaly when validating th…

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/payment/paymentsession/PaymentSessionValidateServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/payment/paymentsession/PaymentSessionValidateServiceImpl.java
@@ -270,7 +270,7 @@ public class PaymentSessionValidateServiceImpl implements PaymentSessionValidate
     Query<InvoiceTerm> invoiceTermQuery =
         invoiceTermRepo
             .all()
-            .filter("self.paymentSession = :paymentSession")
+            .filter("self.paymentSession = :paymentSession AND self.paymentAmount > 0")
             .bind("paymentSession", paymentSession)
             .order("id");
 

--- a/changelogs/unreleased/76327.yml
+++ b/changelogs/unreleased/76327.yml
@@ -1,0 +1,2 @@
+title: "PAYMENTSESSION / BANKORDER : Correct anomaly when validating the payment session causing amount being updated and not corresponding to the value of the amount being validated and equal to the bank order generated."
+module: axelor-account

--- a/changelogs/unreleased/76327.yml
+++ b/changelogs/unreleased/76327.yml
@@ -1,2 +1,2 @@
-title: "PAYMENTSESSION / BANKORDER : Correct anomaly when validating the payment session causing amount being updated and not corresponding to the value of the amount being validated and equal to the bank order generated."
+title: "Payment session: fixed issue when validating the payment session causing amount being updated and not corresponding to the value of the amount being validated and equal to the bank order generated."
 module: axelor-account


### PR DESCRIPTION
…e payment session causing amount being updated and not corresponding to the value of the amount being validated and equal to the bank order generated.