### PR TITLE
Anomaly RM#82944: ADDRESS : Inputing the building number clears the streetName which shouldn't be the case

### DIFF
--- a/axelor-base/src/main/resources/views/Address.xml
+++ b/axelor-base/src/main/resources/views/Address.xml
@@ -27,8 +27,7 @@
         <field name="subDepartment" colSpan="12" x-bind="{{subDepartment|uppercase}}"/>
         <field name="room" x-bind="{{room|uppercase}}" colSpan="12"/>
         <field name="floor" x-bind="{{floor|uppercase}}" colSpan="12"/>
-        <field name="buildingNumber"
-          onChange="action-address-building-number-record-change-streetName"
+        <field name="buildingNumber" onChange="action-address-record-change-building-number"
           x-bind="{{buildingNumber|uppercase}}" colSpan="12"/>
         <field name="street" canNew="true" colSpan="12"
           onChange="action-address-record-change-streetName"
@@ -99,8 +98,7 @@
         <field name="subDepartment" colSpan="12" x-bind="{{subDepartment|uppercase}}"/>
         <field name="room" x-bind="{{room|uppercase}}" colSpan="12"/>
         <field name="floor" x-bind="{{floor|uppercase}}" colSpan="12"/>
-        <field name="buildingNumber"
-          onChange="action-address-building-number-record-change-streetName"
+        <field name="buildingNumber" onChange="action-address-record-change-building-number"
           x-bind="{{buildingNumber|uppercase}}" colSpan="12"/>
         <field name="street" canNew="true" colSpan="12"
           onChange="action-address-record-change-streetName"
@@ -280,14 +278,11 @@
     <field name="country" expr="eval: street.city.country" if="street"/>
   </action-record>
 
-  <action-record name="action-address-building-number-record-change-streetName"
+  <action-record name="action-address-record-change-building-number"
     model="com.axelor.apps.base.db.Address">
     <field name="streetName" expr="eval: buildingNumber + ' ' + street?.name"
       if="buildingNumber &amp;&amp; street"/>
     <field name="streetName" expr="eval: street?.name" if="!buildingNumber &amp;&amp; street"/>
-    <field name="city" expr="eval: street.city" if="street"/>
-    <field name="zip" expr="eval: street.city.zip" if="street"/>
-    <field name="country" expr="eval: street.city.country" if="street"/>
   </action-record>
 
   <search-filters name="address-filters" model="com.axelor.apps.base.db.Address"

--- a/axelor-base/src/main/resources/views/Address.xml
+++ b/axelor-base/src/main/resources/views/Address.xml
@@ -283,6 +283,8 @@
     <field name="streetName" expr="eval: buildingNumber + ' ' + street?.name"
       if="buildingNumber &amp;&amp; street"/>
     <field name="streetName" expr="eval: street?.name" if="!buildingNumber &amp;&amp; street"/>
+    <field name="streetName" expr="eval: null"
+      if="!street &amp;&amp; __config__.app.getApp('base')?.getStoreStreets()"/>
   </action-record>
 
   <search-filters name="address-filters" model="com.axelor.apps.base.db.Address"

--- a/axelor-base/src/main/resources/views/Address.xml
+++ b/axelor-base/src/main/resources/views/Address.xml
@@ -27,7 +27,8 @@
         <field name="subDepartment" colSpan="12" x-bind="{{subDepartment|uppercase}}"/>
         <field name="room" x-bind="{{room|uppercase}}" colSpan="12"/>
         <field name="floor" x-bind="{{floor|uppercase}}" colSpan="12"/>
-        <field name="buildingNumber" onChange="action-address-record-change-streetName"
+        <field name="buildingNumber"
+          onChange="action-address-building-number-record-change-streetName"
           x-bind="{{buildingNumber|uppercase}}" colSpan="12"/>
         <field name="street" canNew="true" colSpan="12"
           onChange="action-address-record-change-streetName"
@@ -98,7 +99,8 @@
         <field name="subDepartment" colSpan="12" x-bind="{{subDepartment|uppercase}}"/>
         <field name="room" x-bind="{{room|uppercase}}" colSpan="12"/>
         <field name="floor" x-bind="{{floor|uppercase}}" colSpan="12"/>
-        <field name="buildingNumber" onChange="action-address-record-change-streetName"
+        <field name="buildingNumber"
+          onChange="action-address-building-number-record-change-streetName"
           x-bind="{{buildingNumber|uppercase}}" colSpan="12"/>
         <field name="street" canNew="true" colSpan="12"
           onChange="action-address-record-change-streetName"
@@ -273,6 +275,16 @@
       if="buildingNumber &amp;&amp; street"/>
     <field name="streetName" expr="eval: street?.name" if="!buildingNumber &amp;&amp; street"/>
     <field name="streetName" expr="eval: null" if="!street"/>
+    <field name="city" expr="eval: street.city" if="street"/>
+    <field name="zip" expr="eval: street.city.zip" if="street"/>
+    <field name="country" expr="eval: street.city.country" if="street"/>
+  </action-record>
+
+  <action-record name="action-address-building-number-record-change-streetName"
+    model="com.axelor.apps.base.db.Address">
+    <field name="streetName" expr="eval: buildingNumber + ' ' + street?.name"
+      if="buildingNumber &amp;&amp; street"/>
+    <field name="streetName" expr="eval: street?.name" if="!buildingNumber &amp;&amp; street"/>
     <field name="city" expr="eval: street.city" if="street"/>
     <field name="zip" expr="eval: street.city.zip" if="street"/>
     <field name="country" expr="eval: street.city.country" if="street"/>

--- a/changelogs/unreleased/82944.yml
+++ b/changelogs/unreleased/82944.yml
@@ -1,0 +1,3 @@
+---
+title: "Address: fix the problem that sometimes when we change the building number, the street name is removed."
+module: axelor-base


### PR DESCRIPTION
Sometimes when we change the building number, the street name is removed. Remove this behavior and let the user delete the street name if it has to be modified and reinput a new one.