### PR TITLE
Anomaly RM#85807:Sequence: Instead of #, use AppBase.draftPrefix when…

### DIFF
--- a/axelor-base/src/main/java/com/axelor/apps/base/service/administration/SequenceService.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/administration/SequenceService.java
@@ -439,7 +439,7 @@ public class SequenceService {
    */
   public boolean isEmptyOrDraftSequenceNumber(String sequenceNumber) {
     return Strings.isNullOrEmpty(sequenceNumber)
-        || sequenceNumber.matches(String.format("[\\%s\\*]\\d+", DRAFT_PREFIX));
+        || sequenceNumber.matches(String.format("[\\%s\\*]\\d+", getDraftPrefix()));
   }
 
   /**

--- a/changelogs/unreleased/85807.yml
+++ b/changelogs/unreleased/85807.yml
@@ -1,0 +1,3 @@
+---
+title: "Sequence: fixed draft prefix when checking for the draft sequence number."
+module: axelor-base


### PR DESCRIPTION
… checking for the draft sequence number