### PR TITLE
Anomaly RM#85304: PARTNER / ACCOUNTCONFIG _ 3 accounts are systematic…

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/accountingsituation/AccountingSituationInitServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/accountingsituation/AccountingSituationInitServiceImpl.java
@@ -152,7 +152,7 @@ public class AccountingSituationInitServiceImpl implements AccountingSituationIn
       AccountConfig accountConfig, AccountingSituation situation, int creationMode)
       throws AxelorException {
     Partner partner = situation.getPartner();
-    if (partner.getIsCustomer() == Boolean.FALSE || situation.getCustomerAccount() != null) return;
+    if (!partner.getIsCustomer() || situation.getCustomerAccount() != null) return;
 
     if (accountConfig.getCustomerAccount() == null) {
       throw new AxelorException(
@@ -208,7 +208,7 @@ public class AccountingSituationInitServiceImpl implements AccountingSituationIn
       AccountConfig accountConfig, AccountingSituation situation, int creationMode)
       throws AxelorException {
     Partner partner = situation.getPartner();
-    if (partner.getIsSupplier() == Boolean.FALSE || situation.getSupplierAccount() != null) return;
+    if (!partner.getIsSupplier() || situation.getSupplierAccount() != null) return;
 
     if (accountConfig.getSupplierAccount() == null) {
       throw new AxelorException(
@@ -265,7 +265,7 @@ public class AccountingSituationInitServiceImpl implements AccountingSituationIn
       AccountConfig accountConfig, AccountingSituation situation, int creationMode)
       throws AxelorException {
     Partner partner = situation.getPartner();
-    if (partner.getIsEmployee() == Boolean.FALSE || situation.getEmployeeAccount() != null) return;
+    if (!partner.getIsEmployee() || situation.getEmployeeAccount() != null) return;
 
     if (accountConfig.getEmployeeAccount() == null) {
       throw new AxelorException(

--- a/changelogs/unreleased/85304.yml
+++ b/changelogs/unreleased/85304.yml
@@ -1,0 +1,3 @@
+---
+title: "Partner:  fixed automatic account creation when partner is prospect based on 'Automatic partner account creation mode' in account config."
+module: axelor-account


### PR DESCRIPTION
…ally created when partnerAccountGenerationModeSelect is 'prefix based' regardless of the partner's type