### PR TITLE
Anomaly RM#86716:SALEORDER/TIMETABLE/INVOICE_ The title 'To invoice' …

### DIFF
--- a/axelor-supplychain/src/main/resources/views/SaleOrderInvoicingWizard.xml
+++ b/axelor-supplychain/src/main/resources/views/SaleOrderInvoicingWizard.xml
@@ -58,7 +58,7 @@
   <grid name="invoicing-wizard-timetable-grid" title="Select timetables to invoice"
     edit-icon="false" model="com.axelor.apps.supplychain.db.Timetable" orderBy="estimatedDate"
     editable="true">
-    <field name="toInvoice" type="boolean" title=" "/>
+    <field name="toInvoice" type="boolean"/>
     <field name="estimatedDate" readonly="true"/>
     <field name="amount" readonly="true" x-scale="saleOrder.currency.numberOfDecimals"/>
     <field name="percentage" readonly="true"/>

--- a/changelogs/unreleased/86716.yml
+++ b/changelogs/unreleased/86716.yml
@@ -1,0 +1,3 @@
+---
+title: "Sale order invoicing: fixed the missing title 'To invoice' on the corresponding column when invoicing time table lines from a sale order."
+module: axelor-supplychain


### PR DESCRIPTION
…is missing on the corresponding column when invoicing timeTableLines from a saleOrder