### PR TITLE
fixed undeclared advancePaymentRefundService in VentilateAdvancePaymentRefundState

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/workflow/ventilate/VentilateAdvancePaymentRefundState.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/workflow/ventilate/VentilateAdvancePaymentRefundState.java
@@ -55,7 +55,7 @@ public class VentilateAdvancePaymentRefundState extends VentilateState {
       AccountingSituationService accountingSituationService,
       InvoiceJournalService invoiceJournalService,
       InvoicePfpValidateService invoicePfpValidateService,
-      InvoiceTermPfpToolService invoiceTermPfpToolService) {
+      AdvancePaymentRefundService advancePaymentRefundService) {
     super(
         sequenceService,
         moveCreateFromInvoiceService,
@@ -70,6 +70,7 @@ public class VentilateAdvancePaymentRefundState extends VentilateState {
         invoiceJournalService,
         invoicePfpValidateService,
         invoiceTermPfpToolService);
+      this.advancePaymentRefundService = advancePaymentRefundService;
   }
 
   @Override


### PR DESCRIPTION
This was causing nullPointerExceptions when ventilating advance payment refunds.