### PR TITLE
Fix a case where printing an invoice with the Reports button of an invoice lead to a view with an empty pdf.

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/print/InvoicePrintServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/invoice/print/InvoicePrintServiceImpl.java
@@ -123,7 +123,7 @@ public class InvoicePrintServiceImpl implements InvoicePrintService {
     if (ReportSettings.FORMAT_PDF.equals(FilenameUtils.getExtension(fileName))) {
       Path path = PdfHelper.printCopiesToFile(file, copyNumber).toPath();
       fileCopies =
-          Files.move(path, path.resolveSibling(fileName), StandardCopyOption.REPLACE_EXISTING)
+          Files.move(file.toPath(), path.resolveSibling(fileName), StandardCopyOption.REPLACE_EXISTING)
               .toFile();
     }
     return fileCopies;


### PR DESCRIPTION
It seems to happen when files are stored on Google Cloud Storage (using GCS Fuse to have AOS view it as a normal folder).