### PR TITLE
Anomaly RM#98963: SALEORDER/PROJECTTASK : SoldTime is not set when th…

### DIFF
--- a/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/projecttask/TaskTemplateBusinessProjectServiceImpl.java
+++ b/axelor-business-project/src/main/java/com/axelor/apps/businessproject/service/projecttask/TaskTemplateBusinessProjectServiceImpl.java
@@ -81,8 +81,9 @@ public class TaskTemplateBusinessProjectServiceImpl extends TaskTemplateHrServic
           (Currency) productCompanyService.get(product, "saleCurrency", project.getCompany()));
       task.setUnitCost(product.getCostPrice());
       projectTaskBusinessProjectService.compute(task);
-      task.setSoldTime(task.getBudgetedTime());
-      task.setUpdatedTime(task.getBudgetedTime());
     }
+    BigDecimal budgetedTime = task.getBudgetedTime();
+    task.setSoldTime(budgetedTime);
+    task.setUpdatedTime(budgetedTime);
   }
 }

--- a/changelogs/unreleased/98963.yml
+++ b/changelogs/unreleased/98963.yml
@@ -1,0 +1,3 @@
+---
+title: "Project task: fixed sold time is not set when the task is linked to a task template without a product."
+module: axelor-business-project


### PR DESCRIPTION
…e task is linked to a TaskTemplate without a product set