### PR TITLE
Anomaly RM#106588: Expense ventilation error with multiple dated tax lines

### DIFF
--- a/axelor-human-resource/src/main/java/com/axelor/apps/hr/service/expense/ExpenseTaxConfiguration.java
+++ b/axelor-human-resource/src/main/java/com/axelor/apps/hr/service/expense/ExpenseTaxConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Axelor Business Solutions
+ *
+ * Copyright (C) 2005-2026 Axelor (<http://axelor.com>).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.axelor.apps.hr.service.expense;
+
+import com.axelor.apps.account.db.TaxLine;
+import java.util.Objects;
+
+public class ExpenseTaxConfiguration {
+
+  protected TaxLine taxLine;
+  protected int vatSystem;
+
+  public ExpenseTaxConfiguration(TaxLine taxLine, int vatSystem) {
+    this.taxLine = taxLine;
+    this.vatSystem = vatSystem;
+  }
+
+  public TaxLine getTaxLine() {
+    return taxLine;
+  }
+
+  public int getVatSystem() {
+    return vatSystem;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(taxLine != null ? taxLine.getId() : 0, vatSystem);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+
+    if (!(o instanceof ExpenseTaxConfiguration)) {
+      return false;
+    }
+
+    ExpenseTaxConfiguration other = (ExpenseTaxConfiguration) o;
+
+    return this.vatSystem == other.vatSystem && Objects.equals(this.taxLine, other.taxLine);
+  }
+}

--- a/changelogs/unreleased/106588.yml
+++ b/changelogs/unreleased/106588.yml
@@ -1,0 +1,13 @@
+---
+title: "Expense: fixed an error where ventilating an expense with multiple expense lines on different dates with taxes caused a 'duplicate tax movelines' error."
+module: axelor-human-resource
+developer: |
+  The method `computeExpenseLinesTotalTax` in `ExpenseVentilateServiceImpl` was refactored to group
+  tax amounts by `(TaxLine, vatSystem)` instead of by date. Tax move lines now have `taxLineSet`,
+  `taxRate`, `taxCode`, and `vatSystemSelect` properly set to avoid duplicate detection.
+
+  New class `ExpenseTaxConfiguration` was added to handle tax grouping.
+
+  Modified files:
+  - `ExpenseVentilateServiceImpl.java`
+  - `ExpenseTaxConfiguration.java` (new)


### PR DESCRIPTION
Fixed an error where ventilating an expense with multiple expense lines
on different dates with taxes caused a 'duplicate tax movelines' error.

The method computeExpenseLinesTotalTax was refactored to group tax amounts
by (TaxLine, vatSystem) instead of by date. Tax move lines now have
taxLineSet, taxRate, taxCode, and vatSystemSelect properly set.

New class ExpenseTaxConfiguration was added to handle tax grouping.