### PR TITLE
Anomaly RM#95253: INVOICEREPORTS _ The turnover displayed on the dash…

### DIFF
--- a/axelor-account/src/main/resources/views/Charts.xml
+++ b/axelor-account/src/main/resources/views/Charts.xml
@@ -419,6 +419,8 @@ from InvoiceTerm as self
       AND _invoice.invoice_date BETWEEN
       DATE(:fromDate) AND DATE(:toDate)
       AND _invoice.operation_type_select IN (3,4)
+      AND
+      coalesce(_invoice_line.is_show_total, false) = false
       GROUP BY
       _month_no, _category.name
       ORDER BY

--- a/changelogs/unreleased/95253.yml
+++ b/changelogs/unreleased/95253.yml
@@ -1,0 +1,3 @@
+---
+title: "Invoice chart: fixed the turn over displayed on chart 'Customer Turnover history by month (on invoices)' which wrongly includes end of pack line when show total is true."
+module: axelor-account


### PR DESCRIPTION
…let.invoice.turnover.cust.history is incorrect since it wrongly includes the 'End of Pack' line, which has isShowTotal boolean set to true