### PR TITLE
Anomaly #110344 Analytic: fixed analytic percentage validation bypass…

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/move/control/MoveCheckServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/move/control/MoveCheckServiceImpl.java
@@ -302,6 +302,7 @@ public class MoveCheckServiceImpl implements MoveCheckService {
             moveLine.getAnalyticMoveLineList().stream()
                 .map(AnalyticMoveLine::getAnalyticAxis)
                 .collect(Collectors.toList()));
+        moveLineCheckService.checkAnalyticMoveLinesPercentage(moveLine);
       }
     }
   }

--- a/changelogs/unreleased/110344.yml
+++ b/changelogs/unreleased/110344.yml
@@ -1,0 +1,3 @@
+---
+title: "Analytic: fixed analytic percentage validation bypass when saving a move in edit mode."
+module: axelor-account


### PR DESCRIPTION
… when saving a move in edit mode.