### PR TITLE
Anomaly RM#111632: PAYMENTSESSION : Payment session validation silent…

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/payment/paymentsession/PaymentSessionValidateServiceImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/payment/paymentsession/PaymentSessionValidateServiceImpl.java
@@ -305,7 +305,6 @@ public class PaymentSessionValidateServiceImpl implements PaymentSessionValidate
         } else if (paymentSession.getStatusSelect()
                 == PaymentSessionRepository.STATUS_AWAITING_PAYMENT
             || this.shouldBeProcessed(invoiceTerm)) {
-          offset += invoiceTermList.size();
 
           if (invoiceTerm.getPaymentAmount().compareTo(BigDecimal.ZERO) != 0) {
             this.processInvoiceTerm(
@@ -322,6 +321,7 @@ public class PaymentSessionValidateServiceImpl implements PaymentSessionValidate
         }
       }
 
+      offset += invoiceTermList.size();
       JPA.clear();
     }
 

--- a/changelogs/unreleased/111632.yml
+++ b/changelogs/unreleased/111632.yml
@@ -1,0 +1,3 @@
+---
+title: "Payment Session: fixed pagination skipping invoice terms beyond the first page during session validation."
+module: axelor-account


### PR DESCRIPTION
…ly skips invoice terms when more than 10 terms are selected