### PR TITLE
Migrate IBAN validation from iban4j to iban-commons

### DIFF
--- a/axelor-account/build.gradle
+++ b/axelor-account/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	implementation libs.bcpkix_jdk18on
 
 	implementation libs.ical4j
-	implementation libs.iban4j
+	implementation libs.iban_commons
 	testImplementation libs.mockito
 
 	implementation libs.jaxb_bind_api

--- a/axelor-bank-payment/build.gradle
+++ b/axelor-bank-payment/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	implementation libs.xalan
 	implementation libs.jdom
 
-	implementation libs.iban4j
+	implementation libs.iban_commons
 
 	implementation libs.jaxb_bind_api
 	testImplementation libs.mockito

--- a/axelor-base/build.gradle
+++ b/axelor-base/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	implementation libs.ical4j_extensions
 	implementation libs.ical4j_connector
 
-	implementation libs.iban4j
+	implementation libs.iban_commons
 	implementation libs.jackrabbit_webdav
 	implementation libs.zxing_core
 		// JSch

--- a/axelor-base/src/main/java/com/axelor/apps/base/service/BankDetailsService.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/BankDetailsService.java
@@ -25,9 +25,7 @@ import com.axelor.apps.base.db.BankDetails;
 import com.axelor.apps.base.db.Company;
 import com.axelor.apps.base.db.Currency;
 import com.axelor.apps.base.db.Partner;
-import org.iban4j.IbanFormatException;
-import org.iban4j.InvalidCheckDigitException;
-import org.iban4j.UnsupportedCountryException;
+import de.speedbanking.iban.InvalidIbanException;
 
 public interface BankDetailsService {
 
@@ -109,13 +107,13 @@ public interface BankDetailsService {
   String getActiveCompanyBankDetails(Company company);
 
   /**
-   * Method to validate a iban.
+   * Validates the structural correctness and check digits of a given IBAN string.
+   * <p>
+   * Evaluates the format, country-specific length, and ISO 7064 Mod 97-10 checksum.
    *
-   * @param iban
-   * @throws IbanFormatException
-   * @throws InvalidCheckDigitException
-   * @throws UnsupportedCountryException
+   * @param iban the alphanumeric IBAN string to validate
+   * @throws InvalidIbanException if the string is null, empty, contains invalid characters,
+   * fails length constraints, or has an invalid checksum digit score
    */
-  void validateIban(String iban)
-      throws IbanFormatException, InvalidCheckDigitException, UnsupportedCountryException;
+  void validateIban(String iban) throws InvalidIbanException;
 }

--- a/axelor-base/src/main/java/com/axelor/apps/base/service/BankDetailsServiceImpl.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/BankDetailsServiceImpl.java
@@ -26,16 +26,13 @@ import com.axelor.apps.base.db.Company;
 import com.axelor.apps.base.db.Currency;
 import com.axelor.apps.base.db.Partner;
 import com.axelor.utils.helpers.StringHelper;
+import de.speedbanking.iban.Iban;
+import de.speedbanking.iban.InvalidIbanException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.iban4j.CountryCode;
-import org.iban4j.IbanFormatException;
-import org.iban4j.IbanUtil;
-import org.iban4j.InvalidCheckDigitException;
-import org.iban4j.UnsupportedCountryException;
 
 public class BankDetailsServiceImpl implements BankDetailsService {
 
@@ -176,14 +173,8 @@ public class BankDetailsServiceImpl implements BankDetailsService {
     return domain;
   }
 
-  public void validateIban(String iban)
-      throws IbanFormatException, InvalidCheckDigitException, UnsupportedCountryException {
-    CountryCode countryCode = CountryCode.getByCode(IbanUtil.getCountryCode(iban));
-    if (countryCode == null) {
-      throw new UnsupportedCountryException("Country code is not supported.");
-    }
-    if (IbanUtil.isSupportedCountry(countryCode)) {
-      IbanUtil.validate(iban);
-    }
+  @Override
+  public void validateIban(String iban) throws InvalidIbanException {
+    Iban.validate(iban);
   }
 }

--- a/axelor-base/src/main/java/com/axelor/apps/base/web/BankDetailsController.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/web/BankDetailsController.java
@@ -29,10 +29,8 @@ import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
 import com.axelor.rpc.ActionRequest;
 import com.axelor.rpc.ActionResponse;
+import de.speedbanking.iban.InvalidIbanException;
 import jakarta.inject.Singleton;
-import org.iban4j.IbanFormatException;
-import org.iban4j.InvalidCheckDigitException;
-import org.iban4j.UnsupportedCountryException;
 
 @Singleton
 public class BankDetailsController {
@@ -52,7 +50,7 @@ public class BankDetailsController {
         && bank.getBankDetailsTypeSelect() == BankRepository.BANK_IDENTIFIER_TYPE_IBAN) {
       try {
         Beans.get(BankDetailsService.class).validateIban(bankDetails.getIban());
-      } catch (IbanFormatException | InvalidCheckDigitException | UnsupportedCountryException e) {
+      } catch (InvalidIbanException e) {
         if (request.getAction().endsWith("onchange")) {
           response.setInfo(I18n.get(BaseExceptionMessage.BANK_DETAILS_1));
         }

--- a/axelor-base/src/main/java/com/axelor/apps/base/web/PartnerController.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/web/PartnerController.java
@@ -68,6 +68,7 @@ import com.axelor.utils.helpers.StringHelper;
 import com.axelor.utils.helpers.StringHtmlListBuilder;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import de.speedbanking.iban.InvalidIbanException;
 import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -82,9 +83,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
 import org.eclipse.birt.core.exception.BirtException;
-import org.iban4j.IbanFormatException;
-import org.iban4j.InvalidCheckDigitException;
-import org.iban4j.UnsupportedCountryException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -318,9 +316,7 @@ public class PartnerController {
           LOG.debug("checking iban code : {}", bankDetails.getIban());
           try {
             Beans.get(BankDetailsService.class).validateIban(bankDetails.getIban());
-          } catch (IbanFormatException
-              | InvalidCheckDigitException
-              | UnsupportedCountryException e) {
+          } catch (InvalidIbanException e) {
             ibanInError.add(bankDetails.getIban());
           }
         }

--- a/libs.gradle
+++ b/libs.gradle
@@ -23,7 +23,7 @@ libs.groovy = 'org.apache.groovy:groovy:4.0.28'
 libs.pdfbox = 'org.apache.pdfbox:pdfbox:3.0.0'
 libs.openpdf = 'com.github.librepdf:openpdf:1.4.2'
 
-libs.iban4j = 'org.iban4j:iban4j:3.2.3-RELEASE'
+libs.iban_commons = 'de.speedbanking:iban-commons:1.8.7'
 
 libs.ical4j = 'org.mnode.ical4j:ical4j:2.2.0'
 libs.ical4j_connector = dependencies.create("org.mnode.ical4j:ical4j-connector:1.0.1") {


### PR DESCRIPTION
## Summary

Replaces `iban4j` with [`iban-commons`](https://github.com/SpeedBankingDe/iban-commons) as the IBAN validation library across `axelor-account`, `axelor-bank-payment`, and `axelor-base`.

## Motivation

`iban-commons` is a high-performance, zero-allocation, zero-dependency IBAN & BIC toolkit for Java 8+.

Compared to iban4j it offers:

- **~6× higher throughput** on the rejection path (10,740,280 vs. 1,801,759 ops/s)
- **~2× higher throughput** on the accept path (5,591,566 vs. 2,870,107 ops/s)
- **Zero heap allocation** (0 B/op vs. 1,156 B/op) — no GC pressure on hot paths
- **Zero compile- or runtime dependencies**
- **120 countries** supported (vs. 111 in iban4j), including full SWIFT IBAN Registry
- **Simpler API** — single `InvalidIbanException` replaces several separate exception types
- Active development, Apache 2.0 licensed, available on Maven Central

## Changes

- `libs.gradle`: replace `iban4j:3.2.3-RELEASE` with `iban-commons:1.8.7`
- `axelor-account`, `axelor-bank-payment`, `axelor-base` `build.gradle`: update dependency
- `BankDetailsService` / `BankDetailsServiceImpl`: replace three-exception API with single
  `InvalidIbanException`; implementation simplified to `Iban.validate(iban)` (one line)
- `BankDetailsController`, `PartnerController`: catch `InvalidIbanException` instead of
  three separate iban4j exceptions

## Disclosure

I am an author and maintainer of `iban-commons`.
The library is Apache 2.0 licensed, zero-dependency, and published on Maven Central.