### PR TITLE
Fix invoice delivery address viewer

### DIFF
--- a/axelor-account/src/main/resources/views/Invoice.xml
+++ b/axelor-account/src/main/resources/views/Invoice.xml
@@ -632,7 +632,7 @@
             grid-view="incoterm-grid" if="__config__.app.isApp('supplychain')"/>
           <field name="deliveryAddressStr" colSpan="6" readonlyIf="statusSelect &gt; 1"
             height="5">
-            <viewer>{{record.addressStr}}</viewer>
+            <viewer>{{record.deliveryAddressStr}}</viewer>
           </field>
         </panel>
         <panel-related field="stockMoveSet"

--- a/changelogs/unreleased/invoice-delivery-address-fix.yml
+++ b/changelogs/unreleased/invoice-delivery-address-fix.yml
@@ -1,0 +1,6 @@
+---
+title: Invoice: fixed delivery address displayed in delivery panel
+module: axelor-account
+developer: |
+  Fixed an issue where the invoice delivery panel displayed
+  the invoicing address instead of the delivery address.


### PR DESCRIPTION
### The delivery address panel displays `addressStr` instead of `deliveryAddressStr`.
This issue appears to exist since the original implementation of the feature in AOS 5.3.
Given the trivial and non-breaking nature of this fix, it would be useful to backport it to maintained versions.

### Steps to reproduce:
1. Create an invoice
2. Set a delivery address different from the invoicing address
3. Open the Delivery panel
4. The displayed address is the invoicing address instead of the delivery address

### Note for backports
The viewer syntax evolved across versions.

Older branches (like this one) use:

```xml
<viewer>{{record.addressStr}}</viewer>
```

while newer branches use:

```xml
<viewer><![CDATA[<>{addressStr}</>]]></viewer>
```

Please take care when cherry-picking/backporting this fix to newer maintained branches.
