### PR TITLE
Anomaly RM#113294:Billing address not displayed on delivery slip when…

### DIFF
--- a/axelor-stock/src/main/resources/reports/StockMove.rptdesign
+++ b/axelor-stock/src/main/resources/reports/StockMove.rptdesign
@@ -3072,8 +3072,8 @@ row._outer["first_name"]
                     </text>
                     <text id="4093">
                         <property name="contentType">html</property>
-                        <text-property name="content"><![CDATA[<VALUE-OF format="HTML">if (row["type_select"] == 2 &amp;&amp; row["to_address_str"] != null) {
-    row["to_address_str"].replace(/\n/g, "<br>")
+                        <text-property name="content"><![CDATA[<VALUE-OF format="HTML">if (row["type_select"] == 2 &amp;&amp; row["invoicingAddress"] != null) {
+    row["invoicingAddress"].replace(/\n/g, "<br>")
 } else if (row["type_select"] == 3 &amp;&amp; row["from_address_str"] != null) {
     row["from_address_str"].replace(/\n/g, "<br>")
 } else if (row["type_select"] == 1 &amp;&amp; row["to_stock_location_address"] != null) {

--- a/changelogs/unreleased/113294.yml
+++ b/changelogs/unreleased/113294.yml
@@ -1,0 +1,3 @@
+---
+title: "Stock move: fixed billing address not displayed on delivery BIRT report when address position is set to right."
+module: axelor-stock


### PR DESCRIPTION
… 'Address position' is set to 'Right'