### PR TITLE
Anomaly RM#114547:SALEORDER : Cannot delete a saleOrderLine attached …

### DIFF
--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderLineSupplychainListener.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderLineSupplychainListener.java
@@ -16,16 +16,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package com.axelor.apps.supplychain.service.saleorderline;
+package com.axelor.apps.supplychain.db.repo;
 
-import com.axelor.apps.base.AxelorException;
-import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.sale.db.SaleOrderLine;
+import com.axelor.apps.supplychain.service.saleorderline.SaleOrderLineCheckSupplychainService;
+import com.axelor.inject.Beans;
+import javax.persistence.PreRemove;
 
-public interface SaleOrderLineCheckSupplychainService {
+public class SaleOrderLineSupplychainListener {
 
-  void saleSupplySelectOnChangeCheck(SaleOrderLine saleOrderLine, SaleOrder saleOrder)
-      throws AxelorException;
-
-  void detachCanceledStockMoveLines(SaleOrderLine saleOrderLine);
+  @PreRemove
+  public void preRemove(SaleOrderLine saleOrderLine) {
+    Beans.get(SaleOrderLineCheckSupplychainService.class)
+        .detachCanceledStockMoveLines(saleOrderLine);
+  }
 }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineCheckSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineCheckSupplychainServiceImpl.java
@@ -29,12 +29,17 @@ import com.axelor.apps.sale.db.repo.SaleOrderLineRepository;
 import com.axelor.apps.sale.service.app.AppSaleService;
 import com.axelor.apps.sale.service.saleorderline.SaleOrderLineCheckServiceImpl;
 import com.axelor.apps.stock.db.StockLocation;
+import com.axelor.apps.stock.db.StockMoveLine;
+import com.axelor.apps.stock.db.repo.StockMoveLineRepository;
+import com.axelor.apps.stock.db.repo.StockMoveRepository;
 import com.axelor.apps.stock.service.StockLocationLineService;
 import com.axelor.apps.supplychain.exception.SupplychainExceptionMessage;
 import com.axelor.apps.supplychain.service.app.AppSupplychainService;
 import com.axelor.common.ObjectUtils;
 import com.axelor.i18n.I18n;
 import com.google.inject.Inject;
+import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
 
 public class SaleOrderLineCheckSupplychainServiceImpl extends SaleOrderLineCheckServiceImpl
     implements SaleOrderLineCheckSupplychainService {
@@ -42,17 +47,20 @@ public class SaleOrderLineCheckSupplychainServiceImpl extends SaleOrderLineCheck
   protected StockLocationLineService stockLocationLineService;
   protected AppSupplychainService appSupplychainService;
   protected TaxAccountService taxAccountService;
+  protected StockMoveLineRepository stockMoveLineRepository;
 
   @Inject
   public SaleOrderLineCheckSupplychainServiceImpl(
       AppSaleService appSaleService,
       StockLocationLineService stockLocationLineService,
       AppSupplychainService appSupplychainService,
-      TaxAccountService taxAccountService) {
+      TaxAccountService taxAccountService,
+      StockMoveLineRepository stockMoveLineRepository) {
     super(appSaleService);
     this.stockLocationLineService = stockLocationLineService;
     this.appSupplychainService = appSupplychainService;
     this.taxAccountService = taxAccountService;
+    this.stockMoveLineRepository = stockMoveLineRepository;
   }
 
   @Override
@@ -112,6 +120,24 @@ public class SaleOrderLineCheckSupplychainServiceImpl extends SaleOrderLineCheck
           I18n.get(
               SupplychainExceptionMessage
                   .SALE_ORDER_LINE_PRODUCT_WITH_NON_DEDUCTIBLE_TAX_NOT_AUTHORIZED));
+    }
+  }
+
+  @Override
+  public void detachCanceledStockMoveLines(SaleOrderLine saleOrderLine) {
+    List<StockMoveLine> stockMoveLineList =
+        stockMoveLineRepository
+            .all()
+            .autoFlush(false)
+            .filter(
+                "self.saleOrderLine.id = :id AND (self.stockMove.statusSelect = :statusSelect OR self.plannedStockMove.statusSelect = :statusSelect)")
+            .bind("id", saleOrderLine.getId())
+            .bind("statusSelect", StockMoveRepository.STATUS_CANCELED)
+            .fetch();
+    if (!CollectionUtils.isEmpty(stockMoveLineList)) {
+      for (StockMoveLine stockMoveLine : stockMoveLineList) {
+        stockMoveLine.setSaleOrderLine(null);
+      }
     }
   }
 }

--- a/axelor-supplychain/src/main/resources/domains/SaleOrderLine.xml
+++ b/axelor-supplychain/src/main/resources/domains/SaleOrderLine.xml
@@ -96,6 +96,9 @@
       <field name="reservedQty"/>
     </track>
 
+    <entity-listener
+      class="com.axelor.apps.supplychain.db.repo.SaleOrderLineSupplychainListener"/>
+
   </entity>
 
 </domain-models>

--- a/changelogs/unreleased/114547.yml
+++ b/changelogs/unreleased/114547.yml
@@ -1,0 +1,3 @@
+---
+title: "Sale order: fixed deletion of a sale order line failing when a canceled stock move line still referenced it."
+module: axelor-supplychain


### PR DESCRIPTION
…to a canceled stockMove (for 8.4 and 7.2)Anomaly #114547
SALEORDER : Cannot delete a saleOrderLine attached to a canceled stockMove (for 8.4 and 7.2)