### PR TITLE
Anomaly RM#115108: DataBackup: AutoImportModelMap uses natural keys (…

### DIFF
--- a/axelor-base/src/main/java/com/axelor/apps/base/service/DataBackupCreateService.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/DataBackupCreateService.java
@@ -117,13 +117,6 @@ public class DataBackupCreateService {
           .put("com.axelor.auth.db.User", "self.code = :code")
           .put("com.axelor.auth.db.Permission", "self.name = :name")
           .put("com.axelor.auth.db.Group", "self.code = :code")
-          .put("com.axelor.apps.base.db.Language", "self.code = :code")
-          .put("com.axelor.apps.base.db.BirtTemplate", "self.name = :name")
-          .put("com.axelor.apps.base.db.BirtTemplateParameter", "self.name = :name")
-          .put("com.axelor.apps.crm.db.EventCategory", "self.code = :code")
-          .put("com.axelor.apps.account.db.AccountingConfigTemplate", "self.code = :code")
-          .put("com.axelor.apps.bankpayment.db.BankOrderFileFormat", "self.name = :name")
-          .put("com.axelor.apps.bankpayment.db.BankStatementFileFormat", "self.name = :name")
           .build();
 
   protected DataBackupRepository dataBackupRepository;

--- a/changelogs/unreleased/115108.yml
+++ b/changelogs/unreleased/115108.yml
@@ -1,0 +1,3 @@
+---
+title: "Data backup: fixed AutoImportModelMap using natural keys that are not guaranteed unique and required causing silent data loss on restore."
+module: axelor-base


### PR DESCRIPTION
…name/code) that are not guaranteed unique nor required, causing silent data loss