### PR TITLE
Anomaly RM#115881:SALEORDER/STOCKMOVE/CREDITNOTE : A creditNote gener…

### DIFF
--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/SaleInvoicingStateServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/SaleInvoicingStateServiceImpl.java
@@ -61,7 +61,7 @@ public class SaleInvoicingStateServiceImpl implements SaleInvoicingStateService 
       invoicingState = SALE_ORDER_INVOICE_PARTIALLY_INVOICED;
     }
 
-    if (amountInvoiced.compareTo(BigDecimal.ZERO) == 0) {
+    if (amountInvoiced.compareTo(BigDecimal.ZERO) <= 0) {
       if (atLeastOneInvoiceVentilated(saleOrderLine)
           && exTaxTotal.compareTo(BigDecimal.ZERO) == 0) {
         invoicingState = SALE_ORDER_INVOICE_INVOICED;

--- a/changelogs/unreleased/115881.yml
+++ b/changelogs/unreleased/115881.yml
@@ -1,0 +1,3 @@
+---
+title: "Sale order: fixed the invoicing state wrongly showing 'Partially invoiced' on a sale order fully reimbursed by a refund invoice generated from a stock move reversion, with no prior sale invoice."
+module: axelor-supplychain


### PR DESCRIPTION
…ated from a reversion stockMove wrongly updates the saleOrder with the flag 'Partially Invoiced'