### PR TITLE
Anomaly RM#116196: PURCHASEORDER : Fix receipt state staying "Partial…

### DIFF
--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderReceiptStateServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderReceiptStateServiceImpl.java
@@ -130,12 +130,13 @@ public class PurchaseOrderReceiptStateServiceImpl implements PurchaseOrderReceip
   }
 
   protected void computePurchaseOrderLineReceiptState(PurchaseOrderLine purchaseOrderLine) {
-    if (purchaseOrderLine.getReceivedQty().signum() == 0) {
-      purchaseOrderLine.setReceiptState(PurchaseOrderRepository.STATE_NOT_RECEIVED);
-    } else if (purchaseOrderLine.getReceivedQty().compareTo(purchaseOrderLine.getQty()) < 0) {
-      purchaseOrderLine.setReceiptState(PurchaseOrderRepository.STATE_PARTIALLY_RECEIVED);
-    } else {
+    if (purchaseOrderLine.getQty().signum() == 0
+        || purchaseOrderLine.getReceivedQty().compareTo(purchaseOrderLine.getQty()) >= 0) {
       purchaseOrderLine.setReceiptState(PurchaseOrderRepository.STATE_RECEIVED);
+    } else if (purchaseOrderLine.getReceivedQty().signum() == 0) {
+      purchaseOrderLine.setReceiptState(PurchaseOrderRepository.STATE_NOT_RECEIVED);
+    } else {
+      purchaseOrderLine.setReceiptState(PurchaseOrderRepository.STATE_PARTIALLY_RECEIVED);
     }
   }
 }

--- a/changelogs/unreleased/116196.yml
+++ b/changelogs/unreleased/116196.yml
@@ -1,0 +1,3 @@
+---
+title: "Purchase order: fixed receipt state staying on 'Partially received' when a line's quantity is corrected to 0."
+module: axelor-supplychain


### PR DESCRIPTION
…ly received" when line quantity is corrected to 0