### PR TITLE
RM#116851 : Fix separate-thread controller tool discarding the callab…

### DIFF
--- a/axelor-base/src/main/java/com/axelor/apps/base/callable/ControllerCallableTool.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/callable/ControllerCallableTool.java
@@ -64,11 +64,10 @@ public class ControllerCallableTool<V> {
                 .build(
                     () -> {
                       try {
-                        callable.call();
+                        return callable.call();
                       } catch (Exception e) {
                         throw new RuntimeException(e);
                       }
-                      return null;
                     }));
 
     int processTimeout = Beans.get(AppBaseService.class).getProcessTimeout();

--- a/changelogs/unreleased/116851.yml
+++ b/changelogs/unreleased/116851.yml
@@ -1,0 +1,3 @@
+---
+title: "Fix separate-thread controller tool discarding the callable result, preventing the global budget export file from being downloaded"
+module: axelor-base


### PR DESCRIPTION
…le result, preventing the global budget export file from being downloaded