### PR TITLE
RM#117002 : Base: migrated internal caches (unit conversion, printing template factory, geocoding) to the tenant-aware cache API.

### DIFF
--- a/axelor-base/src/main/java/com/axelor/apps/base/service/MapServiceImpl.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/MapServiceImpl.java
@@ -22,19 +22,19 @@ import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.Address;
 import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.exception.TraceBackService;
+import com.axelor.cache.AxelorCache;
+import com.axelor.cache.CacheBuilder;
 import com.axelor.common.StringUtils;
 import com.axelor.studio.db.repo.AppBaseRepository;
 import com.google.common.base.Strings;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.UriBuilder;
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,8 +43,13 @@ public class MapServiceImpl implements MapService {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private static final Cache<String, Optional<Map<String, Object>>> GEOCODE_CACHE =
-      CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).maximumSize(1000).build();
+  // Geocoding results are tenant-agnostic, so the cache is shared across tenants.
+  private static final AxelorCache<String, Optional<Map<String, Object>>> GEOCODE_CACHE =
+      CacheBuilder.newBuilder("GEOCODE_CACHE")
+          .expireAfterWrite(Duration.ofHours(1))
+          .maximumSize(1000)
+          .nonTenantAware()
+          .build();
 
   protected final AppBaseService appBaseService;
   protected final MapOsmService mapOsmService;
@@ -70,7 +75,7 @@ public class MapServiceImpl implements MapService {
     int mapApiSelect = appBaseService.getAppBase().getMapApiSelect();
     String cacheKey = mapApiSelect + "|" + qString.trim().toLowerCase(Locale.ROOT);
 
-    Optional<Map<String, Object>> cached = GEOCODE_CACHE.getIfPresent(cacheKey);
+    Optional<Map<String, Object>> cached = GEOCODE_CACHE.get(cacheKey);
     if (cached != null) {
       return cached.orElse(null);
     }

--- a/axelor-base/src/main/java/com/axelor/apps/base/service/UnitConversionServiceImpl.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/UnitConversionServiceImpl.java
@@ -31,22 +31,21 @@ import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.exception.TraceBackService;
 import com.axelor.auth.AuthUtils;
 import com.axelor.auth.db.User;
+import com.axelor.cache.AxelorCache;
+import com.axelor.cache.CacheBuilder;
 import com.axelor.db.Model;
-import com.axelor.db.tenants.TenantResolver;
 import com.axelor.i18n.I18n;
 import com.axelor.utils.template.TemplateMaker;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import jakarta.inject.Inject;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.codehaus.groovy.control.CompilationFailedException;
@@ -58,11 +57,10 @@ public class UnitConversionServiceImpl implements UnitConversionService {
   protected static final char TEMPLATE_DELIMITER = '$';
   protected static final int DEFAULT_COEFFICIENT_SCALE = 12;
 
-  private static final Cache<String, List<UnitConversion>> unitConversionCache =
-      CacheBuilder.newBuilder()
-          .expireAfterWrite(10, TimeUnit.MINUTES)
+  private static final AxelorCache<String, List<UnitConversion>> unitConversionCache =
+      CacheBuilder.newBuilder("unitConversionCache")
+          .expireAfterWrite(Duration.ofMinutes(10))
           .maximumSize(500)
-          .recordStats()
           .build();
 
   protected AppBaseService appBaseService;
@@ -266,7 +264,7 @@ public class UnitConversionServiceImpl implements UnitConversionService {
   protected List<UnitConversion> fetchUnitConversionList(
       Unit startUnit, Unit endUnit, boolean autoFlush) {
     String key = getKey(startUnit, endUnit);
-    List<UnitConversion> unitConversionList = unitConversionCache.getIfPresent(key);
+    List<UnitConversion> unitConversionList = unitConversionCache.get(key);
     if (unitConversionList != null) {
       return unitConversionList;
     }
@@ -285,12 +283,12 @@ public class UnitConversionServiceImpl implements UnitConversionService {
   }
 
   protected String getKey(Unit startUnit, Unit endUnit) {
-    return TenantResolver.currentTenantIdentifier()
-        + "::"
-        + Stream.of(startUnit.getId(), endUnit.getId())
-            .sorted()
-            .map(String::valueOf)
-            .collect(Collectors.joining("::"));
+    // Tenant segregation is handled by the tenant-aware AxelorCache, so the key only needs the
+    // units.
+    return Stream.of(startUnit.getId(), endUnit.getId())
+        .sorted()
+        .map(String::valueOf)
+        .collect(Collectors.joining("::"));
   }
 
   @Override

--- a/axelor-base/src/main/java/com/axelor/apps/base/service/printing/template/PrintingGeneratorFactoryProviderImpl.java
+++ b/axelor-base/src/main/java/com/axelor/apps/base/service/printing/template/PrintingGeneratorFactoryProviderImpl.java
@@ -18,11 +18,11 @@
  */
 package com.axelor.apps.base.service.printing.template;
 
+import com.axelor.cache.AxelorCache;
+import com.axelor.cache.CacheBuilder;
 import com.axelor.meta.MetaScanner;
 import com.axelor.meta.MetaStore;
 import com.axelor.meta.schema.views.Selection.Option;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import java.util.Optional;
 import org.apache.commons.lang3.ClassUtils;
 
@@ -32,12 +32,12 @@ public class PrintingGeneratorFactoryProviderImpl implements PrintingGeneratorFa
   protected static final String PRINTING_TEMPLATE_TYPE_SELECT =
       "base.printing.template.type.select";
 
-  protected static final Cache<Integer, Class<? extends PrintingGeneratorFactory>> CACHE =
-      CacheBuilder.newBuilder().maximumSize(100).weakValues().build();
+  protected static final AxelorCache<Integer, Class<? extends PrintingGeneratorFactory>> CACHE =
+      CacheBuilder.newBuilder("printFactory").maximumSize(100).build();
 
   @Override
   public Class<? extends PrintingGeneratorFactory> get(Integer type) {
-    Class<? extends PrintingGeneratorFactory> klass = CACHE.getIfPresent(type);
+    Class<? extends PrintingGeneratorFactory> klass = CACHE.get(type);
     if (klass != null) {
       return klass;
     }

--- a/changelogs/unreleased/117002.yml
+++ b/changelogs/unreleased/117002.yml
@@ -1,0 +1,11 @@
+---
+title: "Base: migrated internal caches (unit conversion, printing template factory, geocoding) to the tenant-aware cache API."
+module: axelor-base
+developer: |
+  Migrated the static Guava caches of UnitConversionServiceImpl (unitConversionCache),
+  PrintingGeneratorFactoryProviderImpl (CACHE) and MapServiceImpl (GEOCODE_CACHE) from
+  com.google.common.cache to the sanctioned com.axelor.cache.AxelorCache / CacheBuilder API.
+
+  These caches are now tenant-aware by default. UnitConversionServiceImpl.getKey no longer
+  prepends the tenant identifier manually since isolation is handled by the cache.
+  MapServiceImpl.GEOCODE_CACHE uses nonTenantAware() as geocoding results are tenant-agnostic.


### PR DESCRIPTION
## Ticket
Redmine [#117002](https://redmine.axelor.com/issues/117002) — *Migrate axelor-base static Guava caches to the tenant-aware AxelorCache API* (caching-conformity audit #116988, findings #3/#4/#5).

## Changes
Migrated three static Guava caches in **axelor-base** from `com.google.common.cache` to the sanctioned `com.axelor.cache.AxelorCache` / `CacheBuilder` API:

- `UnitConversionServiceImpl.unitConversionCache` — now tenant-aware; the manual `TenantResolver` prefix in `getKey` was removed since isolation is handled by the cache.
- `PrintingGeneratorFactoryProviderImpl.CACHE` — now tenant-aware (`maximumSize=100`).
- `MapServiceImpl.GEOCODE_CACHE` — geocoding results are tenant-agnostic, so `nonTenantAware()` is used; same bounds (`expireAfterWrite=1h`, `maximumSize=1000`).

No functional change.

## Checks
- `compileJava` + `spotlessApply` OK on axelor-base
- pre-push preflight passed