### PR TITLE
RM#117003 : Base: cleaned up hand-rolled per-instance caches and mutable service state to prevent potential cross-request data mix-ups.

### DIFF
--- a/axelor-cash-management/src/main/java/com/axelor/apps/cash/management/service/ForecastRecapServiceImpl.java
+++ b/axelor-cash-management/src/main/java/com/axelor/apps/cash/management/service/ForecastRecapServiceImpl.java
@@ -55,6 +55,8 @@ import com.axelor.apps.purchase.db.PurchaseOrderLine;
 import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.supplychain.db.Timetable;
 import com.axelor.apps.supplychain.db.repo.TimetableRepository;
+import com.axelor.cache.AxelorCache;
+import com.axelor.cache.CacheBuilder;
 import com.axelor.common.ObjectUtils;
 import com.axelor.db.JPA;
 import com.axelor.db.Model;
@@ -67,10 +69,10 @@ import jakarta.persistence.TypedQuery;
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -97,7 +99,10 @@ public class ForecastRecapServiceImpl implements ForecastRecapService {
   protected InvoiceTermRepository invoiceTermRepo;
   protected JournalService journalService;
 
-  protected Map<Integer, List<Integer>> invoiceStatusMap;
+  protected final AxelorCache<Integer, List<Integer>> invoiceStatusMap =
+      CacheBuilder.newBuilder("invoiceStatusMap")
+          .expireAfterWrite(Duration.ofMinutes(5))
+          .build(this::fetchAvailableStatusList);
 
   @Inject
   public ForecastRecapServiceImpl(
@@ -123,15 +128,13 @@ public class ForecastRecapServiceImpl implements ForecastRecapService {
     forecastRecap.clearForecastRecapLineList();
     forecastRecap.setCurrentBalance(forecastRecap.getStartingBalance());
 
-    invoiceStatusMap = fetchAvailableStatusMap();
     forecastRecapRepo.save(forecastRecap);
   }
 
   protected List<Integer> getDeductionStatusList(int operationTypeSelect) {
     List<Integer> statusList =
         new ArrayList<>(
-            Optional.ofNullable(invoiceStatusMap)
-                .map(m -> m.get(operationTypeSelect))
+            Optional.ofNullable(invoiceStatusMap.get(operationTypeSelect))
                 .orElse(Collections.emptyList()));
     if (!statusList.contains(InvoiceRepository.STATUS_VENTILATED)) {
       statusList.add(InvoiceRepository.STATUS_VENTILATED);
@@ -139,32 +142,21 @@ public class ForecastRecapServiceImpl implements ForecastRecapService {
     return statusList;
   }
 
-  protected Map<Integer, List<Integer>> fetchAvailableStatusMap() {
-    List<Integer> supportedOperationTypeSelect =
-        Arrays.asList(
-            InvoiceRepository.OPERATION_TYPE_SUPPLIER_PURCHASE,
-            InvoiceRepository.OPERATION_TYPE_SUPPLIER_REFUND,
-            InvoiceRepository.OPERATION_TYPE_CLIENT_SALE,
-            InvoiceRepository.OPERATION_TYPE_CLIENT_REFUND);
-    Map<Integer, List<Integer>> invStatusMap = new HashMap<>();
-
-    for (int operationTypeSelect : supportedOperationTypeSelect) {
-      List<Integer> statusSelectList =
-          forecastRecapLineTypeRepo
-              .all()
-              .filter("self.operationTypeSelect = :operationTypeSelect")
-              .bind("operationTypeSelect", operationTypeSelect)
-              .fetchStream()
-              .map(ForecastRecapLineType::getStatusSelect)
-              .map(StringHelper::getIntegerList)
-              .flatMap(Collection::stream)
-              .collect(Collectors.toList());
-      if (statusSelectList.isEmpty()) {
-        statusSelectList.add(0);
-      }
-      invStatusMap.put(operationTypeSelect, statusSelectList);
+  protected List<Integer> fetchAvailableStatusList(Integer operationTypeSelect) {
+    List<Integer> statusSelectList =
+        forecastRecapLineTypeRepo
+            .all()
+            .filter("self.operationTypeSelect = :operationTypeSelect")
+            .bind("operationTypeSelect", operationTypeSelect)
+            .fetchStream()
+            .map(ForecastRecapLineType::getStatusSelect)
+            .map(StringHelper::getIntegerList)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+    if (statusSelectList.isEmpty()) {
+      statusSelectList.add(0);
     }
-    return invStatusMap;
+    return statusSelectList;
   }
 
   @Override

--- a/axelor-crm/src/main/java/com/axelor/apps/crm/service/CrmReportingServiceImpl.java
+++ b/axelor-crm/src/main/java/com/axelor/apps/crm/service/CrmReportingServiceImpl.java
@@ -40,8 +40,6 @@ import java.util.Set;
 
 public class CrmReportingServiceImpl implements CrmReportingService {
 
-  protected String query = "";
-
   protected AppBaseService appBaseService;
   protected static final String PARTNER = "Partner";
   protected static final String LEAD = "eventLead";
@@ -77,7 +75,7 @@ public class CrmReportingServiceImpl implements CrmReportingService {
         }
       }
 
-      this.prepareQuery(crmReporting, isPartner, model);
+      String query = this.prepareQuery(crmReporting, isPartner, model);
       String idList = null;
       Query<Model> q = Query.of((Class<Model>) klass).filter(query);
 
@@ -120,18 +118,20 @@ public class CrmReportingServiceImpl implements CrmReportingService {
     return companySet;
   }
 
-  protected void prepareQuery(CrmReporting crmReporting, boolean isPartner, String model) {
+  protected String prepareQuery(CrmReporting crmReporting, boolean isPartner, String model) {
+    StringBuilder query = new StringBuilder();
     model = Strings.isNullOrEmpty(model) ? "" : model + ".";
 
     if (isPartner) {
-      partnerQuery(crmReporting, model);
+      partnerQuery(query, crmReporting, model);
     } else {
-      leadQuery(crmReporting, model);
+      leadQuery(query, crmReporting, model);
     }
 
     if (!crmReporting.getAgencySet().isEmpty()
         && ((AppCrm) appBaseService.getApp("crm")).getAgenciesManagement())
       this.addParams(
+          query,
           "self."
               + model
               + "agency.id IN ("
@@ -140,6 +140,7 @@ public class CrmReportingServiceImpl implements CrmReportingService {
 
     if (!crmReporting.getIndustrySectorSet().isEmpty())
       this.addParams(
+          query,
           "self."
               + model
               + "industrySector.id IN ("
@@ -148,21 +149,27 @@ public class CrmReportingServiceImpl implements CrmReportingService {
 
     if (appBaseService.getAppBase().getTeamManagement() && !crmReporting.getTeamSet().isEmpty())
       this.addParams(
+          query,
           "self.team.id IN (" + StringHelper.getIdListString(crmReporting.getTeamSet()) + ")");
 
-    if (crmReporting.getFromDate() != null) this.addParams("date(self.createdOn) >= :fromDate");
+    if (crmReporting.getFromDate() != null)
+      this.addParams(query, "date(self.createdOn) >= :fromDate");
 
-    if (crmReporting.getToDate() != null) this.addParams("date(self.createdOn) <= :toDate");
+    if (crmReporting.getToDate() != null) this.addParams(query, "date(self.createdOn) <= :toDate");
+
+    return query.toString();
   }
 
-  private void partnerQuery(CrmReporting crmReporting, String model) {
+  private void partnerQuery(StringBuilder query, CrmReporting crmReporting, String model) {
     if (appBaseService.getAppBase().getEnableMultiCompany()
         && !crmReporting.getCompanySet().isEmpty())
       this.addParams(
+          query,
           "(" + companyQuery("self." + model + "companySet", crmReporting.getCompanySet()) + ")");
 
     if (!crmReporting.getCategorySet().isEmpty())
       this.addParams(
+          query,
           "self."
               + model
               + "partnerCategory.id "
@@ -172,6 +179,7 @@ public class CrmReportingServiceImpl implements CrmReportingService {
 
     if (!crmReporting.getCountrySet().isEmpty())
       this.addParams(
+          query,
           "self."
               + model
               + "partnerAddressList.address.country.id "
@@ -180,10 +188,11 @@ public class CrmReportingServiceImpl implements CrmReportingService {
               + ")");
   }
 
-  private void leadQuery(CrmReporting crmReporting, String model) {
+  private void leadQuery(StringBuilder query, CrmReporting crmReporting, String model) {
     if (appBaseService.getAppBase().getEnableMultiCompany()
         && !crmReporting.getCompanySet().isEmpty())
       this.addParams(
+          query,
           "self."
               + model
               + "company.id IN ("
@@ -192,6 +201,7 @@ public class CrmReportingServiceImpl implements CrmReportingService {
 
     if (!crmReporting.getCategorySet().isEmpty())
       this.addParams(
+          query,
           "self."
               + model
               + "type.id "
@@ -201,6 +211,7 @@ public class CrmReportingServiceImpl implements CrmReportingService {
 
     if (!crmReporting.getCountrySet().isEmpty())
       this.addParams(
+          query,
           "self."
               + model
               + "address.country.id "
@@ -213,11 +224,11 @@ public class CrmReportingServiceImpl implements CrmReportingService {
     return queryStr + ".id IN (" + StringHelper.getIdListString(companies) + ")";
   }
 
-  protected void addParams(String paramQuery) {
-    if (!Strings.isNullOrEmpty(query)) {
-      this.query += " AND ";
+  protected void addParams(StringBuilder query, String paramQuery) {
+    if (query.length() > 0) {
+      query.append(" AND ");
     }
 
-    this.query += paramQuery;
+    query.append(paramQuery);
   }
 }

--- a/axelor-production/src/main/java/com/axelor/apps/production/service/manuforder/ManufOrderServiceImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/manuforder/ManufOrderServiceImpl.java
@@ -93,7 +93,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -103,10 +102,6 @@ import org.slf4j.LoggerFactory;
 public class ManufOrderServiceImpl implements ManufOrderService {
 
   private final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-  // Perf: Thread-safe cache for getDefaultBOM lookups during recursive BOM traversal
-  // Key: Product ID, Value: BillOfMaterial (null if no default BOM found)
-  private final Map<Long, BillOfMaterial> defaultBomCache = new ConcurrentHashMap<>();
 
   protected SequenceService sequenceService;
   protected OperationOrderService operationOrderService;
@@ -846,23 +841,30 @@ public class ManufOrderServiceImpl implements ManufOrderService {
    */
   public List<ManufOrder> generateAllSubManufOrder(List<Product> productList, ManufOrder manufOrder)
       throws AxelorException {
-    // Perf: Clear BOM cache before starting recursive BOM traversal
-    defaultBomCache.clear();
-    try {
-      Integer depth = 0;
-      List<ManufOrder> moList = new ArrayList<>();
-      List<Pair<BillOfMaterial, BigDecimal>> childBomList =
-          getToConsumeSubBomList(manufOrder.getBillOfMaterial(), manufOrder, productList);
-      moList.addAll(this.generateChildMOs(manufOrder, childBomList, depth));
-      return moList;
-    } finally {
-      // Clear cache after completion to free memory
-      defaultBomCache.clear();
-    }
+    // Perf: local cache for getDefaultBOM lookups shared across the recursive BOM traversal.
+    // Key: Product ID, Value: BillOfMaterial (absent if no default BOM found).
+    Map<Long, BillOfMaterial> defaultBomCache = new HashMap<>();
+    Integer depth = 0;
+    List<ManufOrder> moList = new ArrayList<>();
+    List<Pair<BillOfMaterial, BigDecimal>> childBomList =
+        getToConsumeSubBomList(
+            manufOrder.getBillOfMaterial(), manufOrder, productList, defaultBomCache);
+    moList.addAll(this.generateChildMOs(manufOrder, childBomList, depth, defaultBomCache));
+    return moList;
   }
 
+  @Override
   public List<Pair<BillOfMaterial, BigDecimal>> getToConsumeSubBomList(
       BillOfMaterial billOfMaterial, ManufOrder mo, List<Product> productList)
+      throws AxelorException {
+    return getToConsumeSubBomList(billOfMaterial, mo, productList, new HashMap<>());
+  }
+
+  protected List<Pair<BillOfMaterial, BigDecimal>> getToConsumeSubBomList(
+      BillOfMaterial billOfMaterial,
+      ManufOrder mo,
+      List<Product> productList,
+      Map<Long, BillOfMaterial> defaultBomCache)
       throws AxelorException {
     List<Pair<BillOfMaterial, BigDecimal>> bomList = new ArrayList<>();
 
@@ -883,7 +885,7 @@ public class ManufOrderServiceImpl implements ManufOrderService {
         }
       } else {
         // Perf: Use cache for getDefaultBOM to avoid repeated DB lookups for same product
-        BillOfMaterial defaultBOM = getDefaultBOMCached(product);
+        BillOfMaterial defaultBOM = getDefaultBOMCached(product, defaultBomCache);
 
         if ((product.getProductSubTypeSelect()
                     == ProductRepository.PRODUCT_SUB_TYPE_FINISHED_PRODUCT
@@ -902,10 +904,12 @@ public class ManufOrderServiceImpl implements ManufOrderService {
    * Get default BOM for a product with caching to avoid repeated DB lookups.
    *
    * @param product The product to get the default BOM for
+   * @param defaultBomCache The traversal-local cache of default BOMs keyed by product id
    * @return The default BillOfMaterial or null if not found
    * @throws AxelorException if an error occurs during BOM lookup
    */
-  protected BillOfMaterial getDefaultBOMCached(Product product) throws AxelorException {
+  protected BillOfMaterial getDefaultBOMCached(
+      Product product, Map<Long, BillOfMaterial> defaultBomCache) throws AxelorException {
     Long productId = product.getId();
     if (defaultBomCache.containsKey(productId)) {
       return defaultBomCache.get(productId);
@@ -1265,7 +1269,10 @@ public class ManufOrderServiceImpl implements ManufOrderService {
   }
 
   protected List<ManufOrder> generateChildMOs(
-      ManufOrder parentMO, List<Pair<BillOfMaterial, BigDecimal>> childBomList, Integer depth)
+      ManufOrder parentMO,
+      List<Pair<BillOfMaterial, BigDecimal>> childBomList,
+      Integer depth,
+      Map<Long, BillOfMaterial> defaultBomCache)
       throws AxelorException {
     List<ManufOrder> manufOrderList = new ArrayList<>();
 
@@ -1297,7 +1304,10 @@ public class ManufOrderServiceImpl implements ManufOrderService {
 
       manufOrderList.addAll(
           this.generateChildMOs(
-              childMO, getToConsumeSubBomList(childMO.getBillOfMaterial(), childMO, null), depth));
+              childMO,
+              getToConsumeSubBomList(childMO.getBillOfMaterial(), childMO, null, defaultBomCache),
+              depth,
+              defaultBomCache));
     }
     return manufOrderList;
   }

--- a/axelor-stock/src/main/java/com/axelor/apps/stock/service/inventory/InventoryLineServiceImpl.java
+++ b/axelor-stock/src/main/java/com/axelor/apps/stock/service/inventory/InventoryLineServiceImpl.java
@@ -34,24 +34,30 @@ import com.axelor.apps.stock.db.repo.StockLocationRepository;
 import com.axelor.apps.stock.service.StockLocationLineFetchService;
 import com.axelor.apps.stock.service.StockLocationLineService;
 import com.axelor.apps.stock.service.config.StockConfigService;
+import com.axelor.cache.AxelorCache;
+import com.axelor.cache.CacheBuilder;
 import com.axelor.inject.Beans;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.inject.persist.Transactional;
 import jakarta.inject.Inject;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
 public class InventoryLineServiceImpl implements InventoryLineService {
 
-  private final Cache<ImmutablePair<Long, Long>, Boolean> presenceCache =
-      CacheBuilder.newBuilder().maximumSize(1000).expireAfterWrite(5, TimeUnit.MINUTES).build();
+  private final AxelorCache<ImmutablePair<Long, Long>, Boolean> presenceCache =
+      CacheBuilder.newBuilder("presenceCache")
+          .maximumSize(1000)
+          .expireAfterWrite(Duration.ofMinutes(5))
+          .build();
 
-  private final Cache<Long, Integer> valuationTypeCache =
-      CacheBuilder.newBuilder().maximumSize(100).expireAfterWrite(5, TimeUnit.MINUTES).build();
+  private final AxelorCache<Long, Integer> valuationTypeCache =
+      CacheBuilder.newBuilder("valuationTypeCache")
+          .maximumSize(100)
+          .expireAfterWrite(Duration.ofMinutes(5))
+          .build();
 
   protected StockConfigService stockConfigService;
   protected InventoryLineRepository inventoryLineRepository;
@@ -296,25 +302,24 @@ public class InventoryLineServiceImpl implements InventoryLineService {
         ImmutablePair.of(
             inventoryLine.getStockLocation().getId(), inventoryLine.getProduct().getId());
 
-    try {
-      return presenceCache.get(
-          key,
-          () ->
-              stockLocationLineFetchService.getStockLocationLine(
-                      inventoryLine.getStockLocation(), inventoryLine.getProduct())
-                  != null);
-    } catch (Exception e) {
-      throw new RuntimeException("Error checking presence in stock location", e);
-    }
+    return presenceCache.get(
+        key,
+        k ->
+            stockLocationLineFetchService.getStockLocationLine(
+                    inventoryLine.getStockLocation(), inventoryLine.getProduct())
+                != null);
   }
 
   protected int getInventoryValuationTypeSelect(Company company) {
-    try {
-      return valuationTypeCache.get(
-          company.getId(),
-          () -> stockConfigService.getStockConfig(company).getInventoryValuationTypeSelect());
-    } catch (Exception e) {
-      throw new RuntimeException("Error fetching valuation type for company " + company.getId(), e);
-    }
+    return valuationTypeCache.get(
+        company.getId(),
+        k -> {
+          try {
+            return stockConfigService.getStockConfig(company).getInventoryValuationTypeSelect();
+          } catch (AxelorException e) {
+            throw new RuntimeException(
+                "Error fetching valuation type for company " + company.getId(), e);
+          }
+        });
   }
 }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/MrpServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/MrpServiceImpl.java
@@ -224,6 +224,14 @@ public class MrpServiceImpl implements MrpService {
   @Override
   @Transactional
   public void reset(Mrp mrp) {
+    // Clear per-run in-memory state so a reused service instance does not carry over data from a
+    // previous calculation.
+    this.stockLocationList = null;
+    this.productMap = null;
+    this.productMapToBeAssigned = null;
+    this.processedMrpForecastIdSet = null;
+    this.currentLevel = null;
+
     today = appBaseService.getTodayDate(mrp.getStockLocation().getCompany());
 
     mrpLineRepository

--- a/changelogs/unreleased/117003.yml
+++ b/changelogs/unreleased/117003.yml
@@ -1,0 +1,21 @@
+---
+title: "Base: cleaned up hand-rolled per-instance caches and mutable service state to prevent potential cross-request data mix-ups."
+module: axelor-base
+developer: |
+  Caching conformity clean-up (tech-debt / future-proofing) across several services:
+
+  - axelor-supplychain MrpServiceImpl: reset() now clears the per-run in-memory state
+    (stockLocationList, productMap, productMapToBeAssigned, processedMrpForecastIdSet, currentLevel)
+    so a reused instance no longer carries data over from a previous calculation.
+  - axelor-stock InventoryLineServiceImpl: presenceCache and valuationTypeCache migrated from
+    com.google.common.cache to the tenant-aware com.axelor.cache.AxelorCache / CacheBuilder API.
+  - axelor-production ManufOrderServiceImpl: defaultBomCache is no longer an instance field; it is
+    a traversal-local map threaded through the recursion. Signatures of the protected methods
+    getDefaultBOMCached and generateChildMOs now take an extra Map<Long, BillOfMaterial> parameter,
+    and a protected getToConsumeSubBomList overload with that parameter was added.
+  - axelor-cash-management ForecastRecapServiceImpl: invoiceStatusMap is now a tenant-aware
+    AxelorCache with a loader; the protected fetchAvailableStatusMap() method was replaced by
+    fetchAvailableStatusList(Integer).
+  - axelor-crm CrmReportingServiceImpl: removed the mutable "query" field; the query string is now
+    a local StringBuilder. The protected prepareQuery method now returns a String and addParams now
+    takes the StringBuilder as first parameter.


### PR DESCRIPTION
## Ticket
Redmine [#117003](https://redmine.axelor.com/issues/117003) — *Caching conformity clean-up: per-instance caches and mutable service state* (caching-conformity audit #116988, findings #6-#10).

These are not active leaks today (services are not `@Singleton` → new instance per lookup) but are cleaned up / future-proofed.

## Changes
- **axelor-supplychain** `MrpServiceImpl`: `reset()` now clears the per-run in-memory state (`stockLocationList`, `productMap`, `productMapToBeAssigned`, `processedMrpForecastIdSet`, `currentLevel`) so a reused instance no longer carries data over between calculations.
- **axelor-stock** `InventoryLineServiceImpl`: `presenceCache` and `valuationTypeCache` migrated from Guava to the tenant-aware `AxelorCache`.
- **axelor-production** `ManufOrderServiceImpl`: `defaultBomCache` is no longer an instance field; it is a traversal-local map threaded through the recursion. `getDefaultBOMCached` and `generateChildMOs` take an extra `Map<Long, BillOfMaterial>` parameter, and a protected `getToConsumeSubBomList` overload was added.
- **axelor-cash-management** `ForecastRecapServiceImpl`: `invoiceStatusMap` is now a tenant-aware `AxelorCache` with a loader; `fetchAvailableStatusMap()` replaced by `fetchAvailableStatusList(Integer)`.
- **axelor-crm** `CrmReportingServiceImpl`: removed the mutable `query` field; the query is now a local `StringBuilder`. `prepareQuery` returns a `String` and `addParams` takes the `StringBuilder` as first parameter.

## Checks
- `compileJava` + `spotlessApply` OK on the 5 modules
- pre-push preflight passed