### PR TITLE
RM#117004 : Fiscal year period: fixed an issue where closing a fiscal period could display accounting entries and anomaly counts belonging to another company or tenant.

### DIFF
--- a/axelor-account/src/main/java/com/axelor/apps/account/service/period/PeriodServiceAccount.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/period/PeriodServiceAccount.java
@@ -37,9 +37,9 @@ public interface PeriodServiceAccount {
   @CallMethod
   public boolean isTemporarilyClosurePeriodManage(Period period, User user) throws AxelorException;
 
-  List<Move> getMoves();
+  List<Move> getMoves(Period period);
 
-  int getAnomalyCount();
+  int getAnomalyCount(Period period);
 
   List<TraceBack> getAnomalies(String moveIds, int anomalyCount);
 }

--- a/axelor-account/src/main/java/com/axelor/apps/account/service/period/PeriodServiceAccountImpl.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/service/period/PeriodServiceAccountImpl.java
@@ -36,9 +36,12 @@ import com.axelor.apps.base.service.PeriodServiceImpl;
 import com.axelor.apps.base.service.user.UserRoleToolService;
 import com.axelor.auth.AuthUtils;
 import com.axelor.auth.db.User;
+import com.axelor.cache.AxelorCache;
+import com.axelor.cache.CacheBuilder;
 import com.axelor.db.Query;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -56,8 +59,14 @@ public class PeriodServiceAccountImpl extends PeriodServiceImpl implements Perio
   protected PeriodCheckService periodCheckService;
   protected TraceBackRepository traceBackRepository;
 
-  protected List<Move> moves = new ArrayList<>();
-  protected int anomalyCount = 0;
+  // Per-request closing result must not be held in scalar instance fields on this @Singleton
+  // service: a concurrent close() from another tenant/user would overwrite it. It is stored in a
+  // tenant-aware cache keyed by period id, so each closing keeps its own moves / anomaly count.
+  protected final AxelorCache<Long, Pair<List<Move>, Integer>> periodClosingResultCache =
+      CacheBuilder.newBuilder("periodClosingResult")
+          .maximumSize(1000)
+          .expireAfterWrite(Duration.ofHours(1))
+          .build();
 
   @Inject
   public PeriodServiceAccountImpl(
@@ -80,6 +89,9 @@ public class PeriodServiceAccountImpl extends PeriodServiceImpl implements Perio
 
   @Override
   public void close(Period period) throws AxelorException {
+    Long periodId = period.getId();
+    List<Move> moves = new ArrayList<>();
+    int anomalyCount = 0;
     if (period.getYear().getTypeSelect() == YearRepository.TYPE_FISCAL) {
       Pair<List<Move>, Integer> result =
           moveValidateService.accountingMultiple(
@@ -88,6 +100,7 @@ public class PeriodServiceAccountImpl extends PeriodServiceImpl implements Perio
       anomalyCount = result.getRight();
       period = periodRepo.find(period.getId());
     }
+    periodClosingResultCache.put(periodId, Pair.of(moves, anomalyCount));
     if (!CollectionUtils.isEmpty(moves)) {
       return;
     }
@@ -153,19 +166,22 @@ public class PeriodServiceAccountImpl extends PeriodServiceImpl implements Perio
   public void closePeriod(Period period) {
     int oldPeriodStatusSelect = period.getStatusSelect();
     super.closePeriod(period);
-    if (!CollectionUtils.isEmpty(moves)) {
+    Pair<List<Move>, Integer> result = periodClosingResultCache.get(period.getId());
+    if (result != null && !CollectionUtils.isEmpty(result.getLeft())) {
       resetStatus(period, oldPeriodStatusSelect);
     }
   }
 
   @Override
-  public List<Move> getMoves() {
-    return moves;
+  public List<Move> getMoves(Period period) {
+    Pair<List<Move>, Integer> result = periodClosingResultCache.get(period.getId());
+    return result != null ? result.getLeft() : new ArrayList<>();
   }
 
   @Override
-  public int getAnomalyCount() {
-    return anomalyCount;
+  public int getAnomalyCount(Period period) {
+    Pair<List<Move>, Integer> result = periodClosingResultCache.get(period.getId());
+    return result != null ? result.getRight() : 0;
   }
 
   @Override

--- a/axelor-account/src/main/java/com/axelor/apps/account/web/PeriodController.java
+++ b/axelor-account/src/main/java/com/axelor/apps/account/web/PeriodController.java
@@ -54,8 +54,8 @@ public class PeriodController {
       controllerCallableTool.runInSeparateThread(closePeriodCallableService, response);
 
       PeriodServiceAccount periodServiceAccount = Beans.get(PeriodServiceAccount.class);
-      List<Move> moves = periodServiceAccount.getMoves();
-      int anomalyCount = periodServiceAccount.getAnomalyCount();
+      List<Move> moves = periodServiceAccount.getMoves(period);
+      int anomalyCount = periodServiceAccount.getAnomalyCount(period);
 
       if (!CollectionUtils.isEmpty(moves)) {
         response.setView(

--- a/changelogs/unreleased/117004.yml
+++ b/changelogs/unreleased/117004.yml
@@ -1,0 +1,14 @@
+---
+title: "Fiscal year period: fixed an issue where closing a fiscal period could display accounting entries and anomaly counts belonging to another company or tenant."
+module: axelor-account
+developer: |
+  PeriodServiceAccountImpl is a @Singleton but stored the per-request closing result (list of moves
+  and anomaly count) in scalar instance fields, which a concurrent close() from another tenant/user
+  could overwrite (cross-tenant leak) with unbounded memory growth.
+
+  The result is now stored in a tenant-aware com.axelor.cache.AxelorCache keyed by period id (bounded
+  and expiring), so each closing keeps its own moves / anomaly count.
+
+  API changes (PeriodServiceAccount): getMoves() and getAnomalyCount() now take the Period as a
+  parameter (getMoves(Period) / getAnomalyCount(Period)). The moves / anomalyCount instance fields
+  were removed.


### PR DESCRIPTION
## Ticket
Redmine [#117004](https://redmine.axelor.com/issues/117004) — *PeriodServiceAccountImpl: cross-tenant leak of Moves/anomalyCount on period close* (caching-conformity audit #116988, finding #1 — CRITICAL). Target version 9.1.7.

## Problem
`PeriodServiceAccountImpl` is a `@Singleton` but stored the per-request closing result (list of moves + anomaly count) in scalar instance fields (`moves`, `anomalyCount`), assigned in `close(Period)` and exposed via `getMoves()`/`getAnomalyCount()`. In a multi-tenant JVM a concurrent/subsequent `close()` from another tenant overwrites them, so a user closing a fiscal period could see accounting Moves / anomaly counts of another company or tenant (plus unbounded memory growth).

## Fix
The result is now stored in a **tenant-aware `com.axelor.cache.AxelorCache` keyed by period id** (bounded, expiring), so each closing keeps its own moves / anomaly count. The worker thread that runs `close()` (via `ControllerCallableTool`) runs under the same tenant, and the controller reads the result back by period id.

### API changes (`PeriodServiceAccount`)
- `getMoves()` → `getMoves(Period period)`
- `getAnomalyCount()` → `getAnomalyCount(Period period)`
- the `moves` / `anomalyCount` instance fields were removed.

`PeriodController.callClosePeriodService` updated accordingly.

## Checks
- `compileJava` + `spotlessApply` OK on axelor-account
- pre-push preflight passed (incl. axelor-account tests)