### PR TITLE
Feature RM#117724: APP CHECK : guard the axelor-supplychain overrides on the installation of the supplychain app

### DIFF
--- a/axelor-budget/src/main/java/com/axelor/apps/budget/db/repo/SaleOrderBudgetRepository.java
+++ b/axelor-budget/src/main/java/com/axelor/apps/budget/db/repo/SaleOrderBudgetRepository.java
@@ -19,6 +19,7 @@
 package com.axelor.apps.budget.db.repo;
 
 import com.axelor.apps.base.AxelorException;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.budget.db.Budget;
 import com.axelor.apps.budget.db.BudgetDistribution;
 import com.axelor.apps.budget.service.AppBudgetService;
@@ -45,8 +46,9 @@ public class SaleOrderBudgetRepository extends SaleOrderSupplychainRepository {
   @Inject
   public SaleOrderBudgetRepository(
       SaleOrderCopyService saleOrderCopyService,
-      SaleOrderOrderingStatusService saleOrderOrderingStatusService) {
-    super(saleOrderCopyService, saleOrderOrderingStatusService);
+      SaleOrderOrderingStatusService saleOrderOrderingStatusService,
+      AppBaseService appBaseService) {
+    super(saleOrderCopyService, saleOrderOrderingStatusService, appBaseService);
   }
 
   @Override

--- a/axelor-contract/src/main/java/com/axelor/apps/contract/service/AnalyticMoveLineParentContractServiceImpl.java
+++ b/axelor-contract/src/main/java/com/axelor/apps/contract/service/AnalyticMoveLineParentContractServiceImpl.java
@@ -24,6 +24,7 @@ import com.axelor.apps.account.db.repo.MoveLineMassEntryRepository;
 import com.axelor.apps.account.db.repo.MoveLineRepository;
 import com.axelor.apps.account.service.analytic.AnalyticLineService;
 import com.axelor.apps.base.AxelorException;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.contract.db.Contract;
 import com.axelor.apps.contract.db.ContractLine;
 import com.axelor.apps.contract.db.ContractVersion;
@@ -50,6 +51,7 @@ public class AnalyticMoveLineParentContractServiceImpl
       MoveLineMassEntryRepository moveLineMassEntryRepository,
       PurchaseOrderLineRepository purchaseOrderLineRepository,
       SaleOrderLineRepository saleOrderLineRepository,
+      AppBaseService appBaseService,
       ContractLineRepository contractLineRepository) {
     super(
         analyticLineService,
@@ -57,7 +59,8 @@ public class AnalyticMoveLineParentContractServiceImpl
         invoiceLineRepository,
         moveLineMassEntryRepository,
         purchaseOrderLineRepository,
-        saleOrderLineRepository);
+        saleOrderLineRepository,
+        appBaseService);
     this.contractLineRepository = contractLineRepository;
   }
 

--- a/axelor-contract/src/main/java/com/axelor/apps/contract/service/WorkflowCancelServiceContractImpl.java
+++ b/axelor-contract/src/main/java/com/axelor/apps/contract/service/WorkflowCancelServiceContractImpl.java
@@ -21,6 +21,7 @@ package com.axelor.apps.contract.service;
 import com.axelor.apps.account.db.Invoice;
 import com.axelor.apps.account.db.InvoiceLine;
 import com.axelor.apps.base.AxelorException;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.contract.db.repo.ConsumptionLineRepository;
 import com.axelor.apps.purchase.db.repo.PurchaseOrderRepository;
 import com.axelor.apps.sale.db.repo.SaleOrderRepository;
@@ -43,6 +44,7 @@ public class WorkflowCancelServiceContractImpl extends WorkflowCancelServiceSupp
       PurchaseOrderRepository purchaseOrderRepository,
       SaleInvoicingStateService saleInvoicingStateService,
       TimetableService timetableService,
+      AppBaseService appBaseService,
       ConsumptionLineRepository consumptionLineRepo) {
     super(
         saleOrderInvoiceService,
@@ -50,7 +52,8 @@ public class WorkflowCancelServiceContractImpl extends WorkflowCancelServiceSupp
         saleOrderRepository,
         purchaseOrderRepository,
         saleInvoicingStateService,
-        timetableService);
+        timetableService,
+        appBaseService);
     this.consumptionLineRepo = consumptionLineRepo;
   }
 

--- a/axelor-contract/src/main/java/com/axelor/apps/contract/service/pricing/PricingGroupContractServiceImpl.java
+++ b/axelor-contract/src/main/java/com/axelor/apps/contract/service/pricing/PricingGroupContractServiceImpl.java
@@ -21,6 +21,7 @@ package com.axelor.apps.contract.service.pricing;
 import com.axelor.apps.account.db.InvoiceLine;
 import com.axelor.apps.base.db.Pricing;
 import com.axelor.apps.base.db.repo.PricingRepository;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.pricing.PricingGenericService;
 import com.axelor.apps.supplychain.service.pricing.PricingGroupSupplyChainServiceImpl;
 import jakarta.inject.Inject;
@@ -28,8 +29,9 @@ import jakarta.inject.Inject;
 public class PricingGroupContractServiceImpl extends PricingGroupSupplyChainServiceImpl {
 
   @Inject
-  public PricingGroupContractServiceImpl(PricingGenericService pricingGenericService) {
-    super(pricingGenericService);
+  public PricingGroupContractServiceImpl(
+      PricingGenericService pricingGenericService, AppBaseService appBaseService) {
+    super(pricingGenericService, appBaseService);
   }
 
   @Override

--- a/axelor-production/src/main/java/com/axelor/apps/production/service/TrackingNumberCompanyProductionServiceImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/TrackingNumberCompanyProductionServiceImpl.java
@@ -20,6 +20,7 @@ package com.axelor.apps.production.service;
 
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.Company;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.production.db.ManufOrder;
 import com.axelor.apps.stock.db.StockMove;
 import com.axelor.apps.stock.db.StockMoveLine;
@@ -35,8 +36,8 @@ public class TrackingNumberCompanyProductionServiceImpl
 
   @Inject
   public TrackingNumberCompanyProductionServiceImpl(
-      StockMoveLineRepository stockMoveLineRepository) {
-    super(stockMoveLineRepository);
+      StockMoveLineRepository stockMoveLineRepository, AppBaseService appBaseService) {
+    super(stockMoveLineRepository, appBaseService);
   }
 
   @Override

--- a/axelor-production/src/main/java/com/axelor/apps/production/service/configurator/ConfiguratorCheckServiceProductionImpl.java
+++ b/axelor-production/src/main/java/com/axelor/apps/production/service/configurator/ConfiguratorCheckServiceProductionImpl.java
@@ -21,6 +21,7 @@ package com.axelor.apps.production.service.configurator;
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.Product;
 import com.axelor.apps.base.db.repo.TraceBackRepository;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.production.db.repo.BillOfMaterialRepository;
 import com.axelor.apps.production.db.repo.ManufOrderRepository;
 import com.axelor.apps.production.db.repo.ProdProcessRepository;
@@ -46,8 +47,9 @@ public class ConfiguratorCheckServiceProductionImpl
       ProductionOrderRepository productionOrderRepository,
       ManufOrderRepository manufOrderRepository,
       BillOfMaterialRepository billOfMaterialRepository,
-      ProdProcessRepository prodProcessRepository) {
-    super(saleOrderLineRepository);
+      ProdProcessRepository prodProcessRepository,
+      AppBaseService appBaseService) {
+    super(saleOrderLineRepository, appBaseService);
     this.productionOrderRepository = productionOrderRepository;
     this.manufOrderRepository = manufOrderRepository;
     this.billOfMaterialRepository = billOfMaterialRepository;

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/AnalyticMoveLineSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/AnalyticMoveLineSupplychainRepository.java
@@ -21,17 +21,15 @@ package com.axelor.apps.supplychain.db.repo;
 import com.axelor.apps.account.db.AnalyticMoveLine;
 import com.axelor.apps.account.db.repo.AnalyticMoveLineMngtRepository;
 import com.axelor.apps.base.service.app.AppBaseService;
-import jakarta.inject.Inject;
+import com.axelor.inject.Beans;
 
 public class AnalyticMoveLineSupplychainRepository extends AnalyticMoveLineMngtRepository {
-
-  @Inject protected AppBaseService appBaseService;
 
   @Override
   public AnalyticMoveLine copy(AnalyticMoveLine entity, boolean deep) {
     AnalyticMoveLine copy = super.copy(entity, deep);
 
-    if (!appBaseService.isApp("supplychain")) {
+    if (!Beans.get(AppBaseService.class).isApp("supplychain")) {
       return copy;
     }
 

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/AnalyticMoveLineSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/AnalyticMoveLineSupplychainRepository.java
@@ -20,11 +20,21 @@ package com.axelor.apps.supplychain.db.repo;
 
 import com.axelor.apps.account.db.AnalyticMoveLine;
 import com.axelor.apps.account.db.repo.AnalyticMoveLineMngtRepository;
+import com.axelor.apps.base.service.app.AppBaseService;
+import jakarta.inject.Inject;
 
 public class AnalyticMoveLineSupplychainRepository extends AnalyticMoveLineMngtRepository {
+
+  @Inject protected AppBaseService appBaseService;
+
   @Override
   public AnalyticMoveLine copy(AnalyticMoveLine entity, boolean deep) {
     AnalyticMoveLine copy = super.copy(entity, deep);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return copy;
+    }
+
     copy.setPurchaseOrderLine(null);
     copy.setSaleOrderLine(null);
     return copy;

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/CartLineSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/CartLineSupplychainRepository.java
@@ -40,6 +40,10 @@ public class CartLineSupplychainRepository extends CartLineManagementRepository 
 
   @Override
   public Map<String, Object> populate(Map<String, Object> json, Map<String, Object> context) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.populate(json, context);
+    }
+
     try {
       if (json != null && json.get("id") != null) {
         CartLine cartLine = find((Long) json.get("id"));

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/LogisticalFormSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/LogisticalFormSupplychainRepository.java
@@ -35,17 +35,18 @@ public class LogisticalFormSupplychainRepository extends LogisticalFormStockRepo
 
   protected PackagingSequenceService packagingSequenceService;
   protected LogisticalFormComputeService logisticalFormComputeService;
-
-  @Inject protected AppBaseService appBaseService;
+  protected final AppBaseService appBaseService;
 
   @Inject
   public LogisticalFormSupplychainRepository(
       LogisticalFormSequenceService logisticalFormSequenceService,
       PackagingSequenceService packagingSequenceService,
-      LogisticalFormComputeService logisticalFormComputeService) {
+      LogisticalFormComputeService logisticalFormComputeService,
+      AppBaseService appBaseService) {
     super(logisticalFormSequenceService);
     this.packagingSequenceService = packagingSequenceService;
     this.logisticalFormComputeService = logisticalFormComputeService;
+    this.appBaseService = appBaseService;
   }
 
   @Override

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/LogisticalFormSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/LogisticalFormSupplychainRepository.java
@@ -18,6 +18,7 @@
  */
 package com.axelor.apps.supplychain.db.repo;
 
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.exception.TraceBackService;
 import com.axelor.apps.stock.db.LogisticalForm;
 import com.axelor.apps.stock.db.StockMove;
@@ -35,6 +36,8 @@ public class LogisticalFormSupplychainRepository extends LogisticalFormStockRepo
   protected PackagingSequenceService packagingSequenceService;
   protected LogisticalFormComputeService logisticalFormComputeService;
 
+  @Inject protected AppBaseService appBaseService;
+
   @Inject
   public LogisticalFormSupplychainRepository(
       LogisticalFormSequenceService logisticalFormSequenceService,
@@ -47,6 +50,10 @@ public class LogisticalFormSupplychainRepository extends LogisticalFormStockRepo
 
   @Override
   public LogisticalForm save(LogisticalForm logisticalForm) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.save(logisticalForm);
+    }
+
     try {
       packagingSequenceService.generatePackagingNumber(logisticalForm);
       logisticalFormComputeService.computeLogisticalForm(logisticalForm);
@@ -59,6 +66,11 @@ public class LogisticalFormSupplychainRepository extends LogisticalFormStockRepo
 
   @Override
   public void remove(LogisticalForm logisticalForm) {
+    if (!appBaseService.isApp("supplychain")) {
+      super.remove(logisticalForm);
+      return;
+    }
+
     List<StockMove> stockMoveList = logisticalForm.getStockMoveList();
     super.remove(logisticalForm);
     if (CollectionUtils.isNotEmpty(stockMoveList)) {

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderLineSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderLineSupplychainRepository.java
@@ -20,6 +20,7 @@ package com.axelor.apps.supplychain.db.repo;
 
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.repo.ProductRepository;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.exception.TraceBackService;
 import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.sale.db.SaleOrderLine;
@@ -33,13 +34,20 @@ import com.axelor.apps.supplychain.service.saleorderline.SaleOrderLineServiceSup
 import com.axelor.apps.supplychain.service.saleorderline.SaleOrderLineSublineService;
 import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
+import jakarta.inject.Inject;
 import java.math.BigDecimal;
 import java.util.Map;
 
 public class SaleOrderLineSupplychainRepository extends SaleOrderLineSaleRepository {
 
+  @Inject protected AppBaseService appBaseService;
+
   @Override
   public Map<String, Object> populate(Map<String, Object> json, Map<String, Object> context) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.populate(json, context);
+    }
+
     Long saleOrderLineId = (Long) json.get("id");
     SaleOrderLine saleOrderLine = find(saleOrderLineId);
 
@@ -79,6 +87,11 @@ public class SaleOrderLineSupplychainRepository extends SaleOrderLineSaleReposit
   @Override
   public SaleOrderLine copy(SaleOrderLine entity, boolean deep) {
     SaleOrderLine copy = super.copy(entity, deep);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return copy;
+    }
+
     copy.setDeliveryState(SaleOrderLineRepository.DELIVERY_STATE_NOT_DELIVERED);
     copy.setInvoicingState(SaleOrderLineRepository.INVOICING_STATE_NOT_INVOICED);
     copy.setDeliveredQty(null);

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderLineSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderLineSupplychainRepository.java
@@ -34,17 +34,14 @@ import com.axelor.apps.supplychain.service.saleorderline.SaleOrderLineServiceSup
 import com.axelor.apps.supplychain.service.saleorderline.SaleOrderLineSublineService;
 import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
-import jakarta.inject.Inject;
 import java.math.BigDecimal;
 import java.util.Map;
 
 public class SaleOrderLineSupplychainRepository extends SaleOrderLineSaleRepository {
 
-  @Inject protected AppBaseService appBaseService;
-
   @Override
   public Map<String, Object> populate(Map<String, Object> json, Map<String, Object> context) {
-    if (!appBaseService.isApp("supplychain")) {
+    if (!Beans.get(AppBaseService.class).isApp("supplychain")) {
       return super.populate(json, context);
     }
 
@@ -88,7 +85,7 @@ public class SaleOrderLineSupplychainRepository extends SaleOrderLineSaleReposit
   public SaleOrderLine copy(SaleOrderLine entity, boolean deep) {
     SaleOrderLine copy = super.copy(entity, deep);
 
-    if (!appBaseService.isApp("supplychain")) {
+    if (!Beans.get(AppBaseService.class).isApp("supplychain")) {
       return copy;
     }
 

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderSupplychainRepository.java
@@ -34,13 +34,15 @@ import jakarta.persistence.PersistenceException;
 
 public class SaleOrderSupplychainRepository extends SaleOrderManagementRepository {
 
-  @Inject protected AppBaseService appBaseService;
+  protected final AppBaseService appBaseService;
 
   @Inject
   public SaleOrderSupplychainRepository(
       SaleOrderCopyService saleOrderCopyService,
-      SaleOrderOrderingStatusService saleOrderOrderingStatusService) {
+      SaleOrderOrderingStatusService saleOrderOrderingStatusService,
+      AppBaseService appBaseService) {
     super(saleOrderCopyService, saleOrderOrderingStatusService);
+    this.appBaseService = appBaseService;
   }
 
   @Override

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/SaleOrderSupplychainRepository.java
@@ -20,6 +20,7 @@ package com.axelor.apps.supplychain.db.repo;
 
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.Partner;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.exception.TraceBackService;
 import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.sale.db.repo.SaleOrderManagementRepository;
@@ -33,6 +34,8 @@ import jakarta.persistence.PersistenceException;
 
 public class SaleOrderSupplychainRepository extends SaleOrderManagementRepository {
 
+  @Inject protected AppBaseService appBaseService;
+
   @Inject
   public SaleOrderSupplychainRepository(
       SaleOrderCopyService saleOrderCopyService,
@@ -42,6 +45,11 @@ public class SaleOrderSupplychainRepository extends SaleOrderManagementRepositor
 
   @Override
   public void remove(SaleOrder order) {
+
+    if (!appBaseService.isApp("supplychain")) {
+      super.remove(order);
+      return;
+    }
 
     Partner partner = order.getClientPartner();
 
@@ -56,6 +64,10 @@ public class SaleOrderSupplychainRepository extends SaleOrderManagementRepositor
 
   @Override
   public SaleOrder save(SaleOrder saleOrder) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.save(saleOrder);
+    }
+
     try {
       Beans.get(SaleOrderLineAnalyticService.class).checkAnalyticAxisByCompany(saleOrder);
     } catch (AxelorException e) {

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveLineSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveLineSupplychainRepository.java
@@ -31,17 +31,14 @@ import com.axelor.apps.supplychain.exception.SupplychainExceptionMessage;
 import com.axelor.apps.supplychain.service.StockMoveLineServiceSupplychain;
 import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
-import jakarta.inject.Inject;
 import jakarta.persistence.PersistenceException;
 import java.util.Map;
 
 public class StockMoveLineSupplychainRepository extends StockMoveLineStockRepository {
 
-  @Inject protected AppBaseService appBaseService;
-
   @Override
   public Map<String, Object> populate(Map<String, Object> json, Map<String, Object> context) {
-    if (!appBaseService.isApp("supplychain")) {
+    if (!Beans.get(AppBaseService.class).isApp("supplychain")) {
       return super.populate(json, context);
     }
 
@@ -82,7 +79,7 @@ public class StockMoveLineSupplychainRepository extends StockMoveLineStockReposi
 
   @Override
   public void remove(StockMoveLine stockMoveLine) {
-    if (!appBaseService.isApp("supplychain")) {
+    if (!Beans.get(AppBaseService.class).isApp("supplychain")) {
       super.remove(stockMoveLine);
       return;
     }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveLineSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveLineSupplychainRepository.java
@@ -21,6 +21,7 @@ package com.axelor.apps.supplychain.db.repo;
 import com.axelor.apps.account.db.repo.AccountingBatchRepository;
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.repo.TraceBackRepository;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.exception.TraceBackService;
 import com.axelor.apps.stock.db.StockMove;
 import com.axelor.apps.stock.db.StockMoveLine;
@@ -30,13 +31,20 @@ import com.axelor.apps.supplychain.exception.SupplychainExceptionMessage;
 import com.axelor.apps.supplychain.service.StockMoveLineServiceSupplychain;
 import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
+import jakarta.inject.Inject;
 import jakarta.persistence.PersistenceException;
 import java.util.Map;
 
 public class StockMoveLineSupplychainRepository extends StockMoveLineStockRepository {
 
+  @Inject protected AppBaseService appBaseService;
+
   @Override
   public Map<String, Object> populate(Map<String, Object> json, Map<String, Object> context) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.populate(json, context);
+    }
+
     try {
       Long stockMoveLineId = (Long) json.get("id");
       StockMoveLine stockMoveLine = find(stockMoveLineId);
@@ -74,6 +82,11 @@ public class StockMoveLineSupplychainRepository extends StockMoveLineStockReposi
 
   @Override
   public void remove(StockMoveLine stockMoveLine) {
+    if (!appBaseService.isApp("supplychain")) {
+      super.remove(stockMoveLine);
+      return;
+    }
+
     try {
       if (stockMoveLine.getPlannedStockMove() == null
           && Beans.get(StockMoveLineServiceSupplychain.class)

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveSupplychainRepository.java
@@ -18,18 +18,26 @@
  */
 package com.axelor.apps.supplychain.db.repo;
 
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.stock.db.StockMove;
 import com.axelor.apps.stock.db.StockMoveLine;
 import com.axelor.apps.stock.db.repo.StockMoveManagementRepository;
 import com.axelor.apps.stock.db.repo.StockMoveRepository;
+import jakarta.inject.Inject;
 import java.math.BigDecimal;
 
 public class StockMoveSupplychainRepository extends StockMoveManagementRepository {
+
+  @Inject protected AppBaseService appBaseService;
 
   @Override
   public StockMove copy(StockMove entity, boolean deep) {
 
     StockMove copy = super.copy(entity, deep);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return copy;
+    }
 
     copy.setInvoiceSet(null);
     copy.setOrigin(null);

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveSupplychainRepository.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/db/repo/StockMoveSupplychainRepository.java
@@ -23,19 +23,17 @@ import com.axelor.apps.stock.db.StockMove;
 import com.axelor.apps.stock.db.StockMoveLine;
 import com.axelor.apps.stock.db.repo.StockMoveManagementRepository;
 import com.axelor.apps.stock.db.repo.StockMoveRepository;
-import jakarta.inject.Inject;
+import com.axelor.inject.Beans;
 import java.math.BigDecimal;
 
 public class StockMoveSupplychainRepository extends StockMoveManagementRepository {
-
-  @Inject protected AppBaseService appBaseService;
 
   @Override
   public StockMove copy(StockMove entity, boolean deep) {
 
     StockMove copy = super.copy(entity, deep);
 
-    if (!appBaseService.isApp("supplychain")) {
+    if (!Beans.get(AppBaseService.class).isApp("supplychain")) {
       return copy;
     }
 

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/rest/PartnerCreationServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/rest/PartnerCreationServiceSupplychainImpl.java
@@ -68,6 +68,11 @@ public class PartnerCreationServiceSupplychainImpl extends PartnerCreationServic
             isCustomer,
             isSupplier,
             isProspect);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return partner;
+    }
+
     baseConvertLeadWizardService.setPartnerFields(partner);
     partner.setAgency(partner.getUser().getActiveAgency());
     return partnerRepository.save(partner);

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/rest/StockProductRestServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/rest/StockProductRestServiceSupplychainImpl.java
@@ -21,6 +21,7 @@ package com.axelor.apps.supplychain.rest;
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.Company;
 import com.axelor.apps.base.db.Product;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.stock.db.StockLocation;
 import com.axelor.apps.stock.rest.StockProductRestServiceImpl;
 import com.axelor.apps.stock.translation.ITranslation;
@@ -29,10 +30,18 @@ import com.axelor.apps.supplychain.service.ProductStockLocationService;
 import com.axelor.i18n.I18n;
 import com.axelor.inject.Beans;
 import com.axelor.utils.api.ResponseConstructor;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import java.util.Map;
 
 public class StockProductRestServiceSupplychainImpl extends StockProductRestServiceImpl {
+
+  protected final AppBaseService appBaseService;
+
+  @Inject
+  public StockProductRestServiceSupplychainImpl(AppBaseService appBaseService) {
+    this.appBaseService = appBaseService;
+  }
 
   /*
    * OVERRIDING
@@ -42,6 +51,10 @@ public class StockProductRestServiceSupplychainImpl extends StockProductRestServ
   @Override
   public Response getProductIndicators(
       Product product, Company company, StockLocation stockLocation) throws AxelorException {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.getProductIndicators(product, company, stockLocation);
+    }
+
     Map<String, Object> stockIndicators;
     if (company == null) {
       stockIndicators =

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/AnalyticMoveLineSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/AnalyticMoveLineSupplychainServiceImpl.java
@@ -68,6 +68,11 @@ public class AnalyticMoveLineSupplychainServiceImpl extends AnalyticMoveLineServ
 
     AnalyticMoveLine analyticMoveLine =
         super.computeAnalyticMoveLine(invoiceLine, invoice, company, analyticAccount);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return analyticMoveLine;
+    }
+
     analyticMoveLine.setSaleOrderLine(invoiceLine.getSaleOrderLine());
     analyticMoveLine.setPurchaseOrderLine(invoiceLine.getPurchaseOrderLine());
     return analyticMoveLine;

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/CallTenderPurchaseOrderSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/CallTenderPurchaseOrderSupplychainServiceImpl.java
@@ -67,6 +67,10 @@ public class CallTenderPurchaseOrderSupplychainServiceImpl
   @Override
   protected PurchaseOrder createPurchaseOrder(
       CallTender callTender, Partner partner, Company company) throws AxelorException {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.createPurchaseOrder(callTender, partner, company);
+    }
+
     PurchaseOrder purchaseOrder =
         purchaseOrderCreateSupplychainService.createPurchaseOrder(
             AuthUtils.getUser(),

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/ConfiguratorCheckServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/ConfiguratorCheckServiceSupplychainImpl.java
@@ -21,6 +21,7 @@ package com.axelor.apps.supplychain.service;
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.Product;
 import com.axelor.apps.base.db.repo.TraceBackRepository;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.sale.db.Configurator;
 import com.axelor.apps.sale.db.repo.SaleOrderLineRepository;
 import com.axelor.apps.sale.service.configurator.ConfiguratorCheckServiceImpl;
@@ -31,17 +32,24 @@ import jakarta.inject.Inject;
 public class ConfiguratorCheckServiceSupplychainImpl extends ConfiguratorCheckServiceImpl {
 
   protected final SaleOrderLineRepository saleOrderLineRepository;
+  protected final AppBaseService appBaseService;
 
   @Inject
-  public ConfiguratorCheckServiceSupplychainImpl(SaleOrderLineRepository saleOrderLineRepository) {
+  public ConfiguratorCheckServiceSupplychainImpl(
+      SaleOrderLineRepository saleOrderLineRepository, AppBaseService appBaseService) {
     super();
     this.saleOrderLineRepository = saleOrderLineRepository;
+    this.appBaseService = appBaseService;
   }
 
   @Override
   public void checkLinkedSaleOrderLine(Configurator configurator, Product product)
       throws AxelorException {
     super.checkLinkedSaleOrderLine(configurator, product);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return;
+    }
 
     var terminatedSOL =
         saleOrderLineRepository
@@ -69,6 +77,10 @@ public class ConfiguratorCheckServiceSupplychainImpl extends ConfiguratorCheckSe
   @Override
   public void checkLinkedSaleOrderLine(Configurator configurator) throws AxelorException {
     super.checkLinkedSaleOrderLine(configurator);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return;
+    }
 
     var terminatedSOL =
         saleOrderLineRepository

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/LogisticalFormCreateServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/LogisticalFormCreateServiceSupplychainImpl.java
@@ -52,6 +52,11 @@ public class LogisticalFormCreateServiceSupplychainImpl extends LogisticalFormCr
       throws AxelorException {
     super.checkFields(
         carrierPartner, deliverToCustomerPartner, isMultiClientEnabled, company, stockLocation);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return;
+    }
+
     if (stockLocation != null && !stockLocation.getUsableOnSaleOrder()) {
       throw new AxelorException(
           TraceBackRepository.CATEGORY_INCONSISTENCY,

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/ProductSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/ProductSupplychainServiceImpl.java
@@ -57,6 +57,11 @@ public class ProductSupplychainServiceImpl extends ProductServicePurchaseImpl {
   @Override
   public void copyProduct(Product product, Product copy) {
     super.copyProduct(product, copy);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return;
+    }
+
     copy.setStockRotationCategory(null);
     copy.setAutoAssignStockRotationCategory(Boolean.TRUE);
     copy.setRevaluationRate(BigDecimal.ZERO);

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderCreateServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderCreateServiceSupplychainImpl.java
@@ -90,6 +90,11 @@ public class PurchaseOrderCreateServiceSupplychainImpl extends PurchaseOrderCrea
             priceList,
             supplierPartner,
             tradingName);
+
+    if (!appSupplychainService.isApp("supplychain")) {
+      return purchaseOrder;
+    }
+
     setIntercoOnPurchaseOrder(purchaseOrder, supplierPartner);
     return purchaseOrder;
   }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderLineTaxComputeSupplychainServiceImp.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderLineTaxComputeSupplychainServiceImp.java
@@ -37,10 +37,13 @@ import java.util.stream.Collectors;
 public class PurchaseOrderLineTaxComputeSupplychainServiceImp
     extends PurchaseOrderLineTaxComputeServiceImpl {
 
+  protected final AppBaseService appBaseService;
+
   @Inject
   public PurchaseOrderLineTaxComputeSupplychainServiceImp(
-      CurrencyScaleService currencyScaleService) {
+      CurrencyScaleService currencyScaleService, AppBaseService appBaseService) {
     super(currencyScaleService);
+    this.appBaseService = appBaseService;
   }
 
   @Override
@@ -50,6 +53,16 @@ public class PurchaseOrderLineTaxComputeSupplychainServiceImp
       List<PurchaseOrderLineTax> purchaseOrderLineTaxList,
       Currency currency,
       List<PurchaseOrderLineTax> currentPurchaseOrderLineTaxList) {
+    if (!appBaseService.isApp("supplychain")) {
+      super.computeAndAddTaxToList(
+          map,
+          purchaseOrderLineSetByTax,
+          purchaseOrderLineTaxList,
+          currency,
+          currentPurchaseOrderLineTaxList);
+      return;
+    }
+
     List<PurchaseOrderLineTax> deductibleTaxList =
         map.values().stream()
             .filter(it -> !this.isNonDeductibleTax(it))

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderMergingServiceSupplyChainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderMergingServiceSupplyChainImpl.java
@@ -128,6 +128,10 @@ public class PurchaseOrderMergingServiceSupplyChainImpl extends PurchaseOrderMer
 
   @Override
   protected boolean isConfirmationNeeded(PurchaseOrderMergingResult result) {
+    if (!appPurchaseService.isApp("supplychain")) {
+      return super.isConfirmationNeeded(result);
+    }
+
     return super.isConfirmationNeeded(result) || getChecks(result).isExistStockLocationDiff();
   }
 
@@ -135,6 +139,11 @@ public class PurchaseOrderMergingServiceSupplyChainImpl extends PurchaseOrderMer
   protected void fillCommonFields(
       List<PurchaseOrder> purchaseOrdersToMerge, PurchaseOrderMergingResult result) {
     super.fillCommonFields(purchaseOrdersToMerge, result);
+
+    if (!appPurchaseService.isApp("supplychain")) {
+      return;
+    }
+
     purchaseOrdersToMerge.stream()
         .map(PurchaseOrder::getStockLocation)
         .filter(Objects::nonNull)
@@ -146,6 +155,11 @@ public class PurchaseOrderMergingServiceSupplyChainImpl extends PurchaseOrderMer
   protected void updateDiffsCommonFields(
       PurchaseOrder purchaseOrder, PurchaseOrderMergingResult result) {
     super.updateDiffsCommonFields(purchaseOrder, result);
+
+    if (!appPurchaseService.isApp("supplychain")) {
+      return;
+    }
+
     CommonFieldsSupplyChainImpl commonFields = getCommonFields(result);
     ChecksSupplyChainImpl checks = getChecks(result);
     if (commonFields.getCommonStockLocation() != null
@@ -161,6 +175,10 @@ public class PurchaseOrderMergingServiceSupplyChainImpl extends PurchaseOrderMer
   protected PurchaseOrder generatePurchaseOrder(
       List<PurchaseOrder> purchaseOrdersToMerge, PurchaseOrderMergingResult result)
       throws AxelorException {
+
+    if (!appPurchaseService.isApp("supplychain")) {
+      return super.generatePurchaseOrder(purchaseOrdersToMerge, result);
+    }
 
     String numSeq =
         computeConcatenatedString(purchaseOrdersToMerge, PurchaseOrder::getPurchaseOrderSeq, "-");
@@ -197,6 +215,11 @@ public class PurchaseOrderMergingServiceSupplyChainImpl extends PurchaseOrderMer
   @Override
   protected void updateResultWithContext(PurchaseOrderMergingResult result, Context context) {
     super.updateResultWithContext(result, context);
+
+    if (!appPurchaseService.isApp("supplychain")) {
+      return;
+    }
+
     if (context.get("stockLocation") != null) {
       getCommonFields(result)
           .setCommonStockLocation(MapHelper.get(context, StockLocation.class, "stockLocation"));
@@ -224,6 +247,10 @@ public class PurchaseOrderMergingServiceSupplyChainImpl extends PurchaseOrderMer
       PurchaseOrder firstPurchaseOrder) {
     super.checkDiffs(purchaseOrdersToMerge, result, firstPurchaseOrder);
 
+    if (!appPurchaseService.isApp("supplychain")) {
+      return;
+    }
+
     if (purchaseOrdersToMerge.stream()
         .anyMatch(order -> order.getInterco() != firstPurchaseOrder.getInterco())) {
       ChecksSupplyChainImpl checks = getChecks(result);
@@ -234,6 +261,10 @@ public class PurchaseOrderMergingServiceSupplyChainImpl extends PurchaseOrderMer
   @Override
   protected void checkErrors(StringJoiner fieldErrors, PurchaseOrderMergingResult result) {
     super.checkErrors(fieldErrors, result);
+
+    if (!appPurchaseService.isApp("supplychain")) {
+      return;
+    }
 
     if (getChecks(result).isExistIntercoDiff()) {
       fieldErrors.add(

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderMergingViewServiceSupplyChainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/PurchaseOrderMergingViewServiceSupplyChainImpl.java
@@ -48,6 +48,11 @@ public class PurchaseOrderMergingViewServiceSupplyChainImpl
       PurchaseOrderMergingResult result, List<PurchaseOrder> purchaseOrdersToMerge) {
 
     ActionViewBuilder confirmView = super.buildConfirmView(result, purchaseOrdersToMerge);
+
+    if (!appPurchaseService.isApp("supplychain")) {
+      return confirmView;
+    }
+
     if (purchaseOrderMergingSupplyChainService.getChecks(result).isExistStockLocationDiff()) {
       confirmView.context("contextLocationToCheck", Boolean.TRUE.toString());
     }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockCorrectionServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockCorrectionServiceSupplychainImpl.java
@@ -64,6 +64,11 @@ public class StockCorrectionServiceSupplychainImpl extends StockCorrectionServic
   public void getDefaultQtys(
       StockLocationLine stockLocationLine, Map<String, Object> stockCorrectionQtys) {
     super.getDefaultQtys(stockLocationLine, stockCorrectionQtys);
+
+    if (!baseService.isApp("supplychain")) {
+      return;
+    }
+
     stockCorrectionQtys.put("reservedQty", stockLocationLine.getReservedQty());
   }
 }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockHistoryServiceSupplyChainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockHistoryServiceSupplyChainImpl.java
@@ -20,6 +20,7 @@ package com.axelor.apps.supplychain.service;
 
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.service.UnitConversionService;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.stock.db.StockHistoryLine;
 import com.axelor.apps.stock.db.StockMoveLine;
 import com.axelor.apps.stock.db.repo.StockHistoryLineManagementRepository;
@@ -32,17 +33,21 @@ import java.util.List;
 
 public class StockHistoryServiceSupplyChainImpl extends StockHistoryServiceImpl {
 
+  protected final AppBaseService appBaseService;
+
   @Inject
   public StockHistoryServiceSupplyChainImpl(
       StockMoveLineRepository stockMoveLineRepository,
       UnitConversionService unitConversionService,
       StockLocationRepository stockLocationRepository,
-      StockHistoryLineManagementRepository stockHistoryLineRepository) {
+      StockHistoryLineManagementRepository stockHistoryLineRepository,
+      AppBaseService appBaseService) {
     super(
         stockMoveLineRepository,
         unitConversionService,
         stockLocationRepository,
         stockHistoryLineRepository);
+    this.appBaseService = appBaseService;
   }
 
   @Override
@@ -51,6 +56,10 @@ public class StockHistoryServiceSupplyChainImpl extends StockHistoryServiceImpl 
       throws AxelorException {
 
     super.fillOutgoingStockHistoryLineFields(stockHistoryLine, stockMoveLineList);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return;
+    }
 
     BigDecimal sumOutQtyPeriod = BigDecimal.ZERO;
     BigDecimal sumOneoffSaleOutQtyPeriod = BigDecimal.ZERO;

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveCurrencyServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveCurrencyServiceSupplychainImpl.java
@@ -19,10 +19,12 @@
 package com.axelor.apps.supplychain.service;
 
 import com.axelor.apps.base.db.Currency;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.purchase.db.PurchaseOrder;
 import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.stock.db.StockMove;
 import com.axelor.apps.stock.service.StockMoveCurrencyServiceImpl;
+import jakarta.inject.Inject;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,8 +35,19 @@ import org.apache.commons.collections.CollectionUtils;
 
 public class StockMoveCurrencyServiceSupplychainImpl extends StockMoveCurrencyServiceImpl {
 
+  protected final AppBaseService appBaseService;
+
+  @Inject
+  public StockMoveCurrencyServiceSupplychainImpl(AppBaseService appBaseService) {
+    this.appBaseService = appBaseService;
+  }
+
   @Override
   public Currency getCurrency(StockMove stockMove) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.getCurrency(stockMove);
+    }
+
     if (isMultiCurrency(stockMove)) {
       return super.getCurrency(stockMove);
     }
@@ -65,6 +78,10 @@ public class StockMoveCurrencyServiceSupplychainImpl extends StockMoveCurrencySe
 
   @Override
   public boolean isMultiCurrency(StockMove stockMove) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.isMultiCurrency(stockMove);
+    }
+
     Set<Currency> currencySet =
         Stream.concat(
                 Optional.ofNullable(stockMove.getSaleOrderSet())

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveLineStockLocationServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveLineStockLocationServiceSupplychainImpl.java
@@ -41,6 +41,10 @@ public class StockMoveLineStockLocationServiceSupplychainImpl
   @Override
   protected boolean isStockLocationMatchingParent(
       StockLocation detailStockLocation, StockLocation parentStockLocation) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.isStockLocationMatchingParent(detailStockLocation, parentStockLocation);
+    }
+
     return detailStockLocation.equals(parentStockLocation)
         || (parentStockLocation.equals(detailStockLocation.getParentStockLocation())
             && detailStockLocation.getUsableOnSaleOrder());

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveMergingServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/StockMoveMergingServiceSupplychainImpl.java
@@ -57,6 +57,11 @@ public class StockMoveMergingServiceSupplychainImpl extends StockMoveMergingServ
   @Override
   protected void checkErrors(List<StockMove> stockMoveList, List<String> errors) {
     super.checkErrors(stockMoveList, errors);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return;
+    }
+
     if (!checkAllSame(
         stockMoveList,
         stockMove ->
@@ -78,6 +83,11 @@ public class StockMoveMergingServiceSupplychainImpl extends StockMoveMergingServ
   @Override
   protected List<Function<StockMove, Object>> getShipmentFieldsToCheck() {
     List<Function<StockMove, Object>> shipmentFieldsToCheck = super.getShipmentFieldsToCheck();
+
+    if (!appBaseService.isApp("supplychain")) {
+      return shipmentFieldsToCheck;
+    }
+
     shipmentFieldsToCheck.add(StockMove::getDeliveryCondition);
     return shipmentFieldsToCheck;
   }
@@ -86,6 +96,11 @@ public class StockMoveMergingServiceSupplychainImpl extends StockMoveMergingServ
   protected void fillStockMoveFields(
       List<StockMove> stockMoveList, StockMove stockMove, StockMove mergedStockMove) {
     super.fillStockMoveFields(stockMoveList, stockMove, mergedStockMove);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return;
+    }
+
     mergedStockMove.setDeliveryCondition(stockMove.getDeliveryCondition());
     mergedStockMove.setSaleOrderSet(
         stockMoveList.stream()

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/TrackingNumberCompanySupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/TrackingNumberCompanySupplychainServiceImpl.java
@@ -20,6 +20,7 @@ package com.axelor.apps.supplychain.service;
 
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.Company;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.purchase.db.PurchaseOrder;
 import com.axelor.apps.purchase.db.PurchaseOrderLine;
 import com.axelor.apps.sale.db.SaleOrder;
@@ -35,15 +36,22 @@ import java.util.Optional;
 
 public class TrackingNumberCompanySupplychainServiceImpl extends TrackingNumberCompanyServiceImpl {
 
+  protected final AppBaseService appBaseService;
+
   @Inject
   public TrackingNumberCompanySupplychainServiceImpl(
-      StockMoveLineRepository stockMoveLineRepository) {
+      StockMoveLineRepository stockMoveLineRepository, AppBaseService appBaseService) {
     super(stockMoveLineRepository);
+    this.appBaseService = appBaseService;
   }
 
   @Override
   protected Optional<Company> getDefaultCompany(TrackingNumber trackingNumber)
       throws AxelorException {
+
+    if (!appBaseService.isApp("supplychain")) {
+      return super.getDefaultCompany(trackingNumber);
+    }
 
     switch (trackingNumber.getOriginMoveTypeSelect()) {
       case TrackingNumberRepository.ORIGIN_MOVE_TYPE_SALE:

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/analytic/AnalyticMoveLineParentSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/analytic/AnalyticMoveLineParentSupplychainServiceImpl.java
@@ -25,6 +25,7 @@ import com.axelor.apps.account.db.repo.MoveLineRepository;
 import com.axelor.apps.account.service.analytic.AnalyticLineService;
 import com.axelor.apps.account.service.analytic.AnalyticMoveLineParentServiceImpl;
 import com.axelor.apps.base.AxelorException;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.purchase.db.PurchaseOrder;
 import com.axelor.apps.purchase.db.PurchaseOrderLine;
 import com.axelor.apps.purchase.db.repo.PurchaseOrderLineRepository;
@@ -41,6 +42,7 @@ public class AnalyticMoveLineParentSupplychainServiceImpl
 
   protected PurchaseOrderLineRepository purchaseOrderLineRepository;
   protected SaleOrderLineRepository saleOrderLineRepository;
+  protected AppBaseService appBaseService;
 
   @Inject
   public AnalyticMoveLineParentSupplychainServiceImpl(
@@ -49,7 +51,8 @@ public class AnalyticMoveLineParentSupplychainServiceImpl
       InvoiceLineRepository invoiceLineRepository,
       MoveLineMassEntryRepository moveLineMassEntryRepository,
       PurchaseOrderLineRepository purchaseOrderLineRepository,
-      SaleOrderLineRepository saleOrderLineRepository) {
+      SaleOrderLineRepository saleOrderLineRepository,
+      AppBaseService appBaseService) {
     super(
         analyticLineService,
         moveLineRepository,
@@ -57,11 +60,17 @@ public class AnalyticMoveLineParentSupplychainServiceImpl
         moveLineMassEntryRepository);
     this.purchaseOrderLineRepository = purchaseOrderLineRepository;
     this.saleOrderLineRepository = saleOrderLineRepository;
+    this.appBaseService = appBaseService;
   }
 
   @Override
   @Transactional(rollbackOn = {Exception.class})
   public void refreshAxisOnParent(AnalyticMoveLine analyticMoveLine) throws AxelorException {
+    if (!appBaseService.isApp("supplychain")) {
+      super.refreshAxisOnParent(analyticMoveLine);
+      return;
+    }
+
     PurchaseOrderLine purchaseOrderLine = analyticMoveLine.getPurchaseOrderLine();
     SaleOrderLine saleOrderLine = analyticMoveLine.getSaleOrderLine();
     AnalyticLineModel analyticLineModel = null;

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/batch/BatchAccountingCutOffSupplyChain.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/batch/BatchAccountingCutOffSupplyChain.java
@@ -73,6 +73,11 @@ public class BatchAccountingCutOffSupplyChain extends BatchAccountingCutOff {
 
   @Override
   protected void process() {
+    if (!appBaseService.isApp("supplychain")) {
+      super.process();
+      return;
+    }
+
     try {
       AccountingBatch accountingBatch = batch.getAccountingBatch();
 
@@ -226,6 +231,10 @@ public class BatchAccountingCutOffSupplyChain extends BatchAccountingCutOff {
 
   @Override
   protected String getProcessedMessage() {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.getProcessedMessage();
+    }
+
     return I18n.get(SupplychainExceptionMessage.ACCOUNTING_CUT_OFF_STOCK_MOVE_PROCESSED);
   }
 }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/batch/SaleBatchSupplyChainService.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/batch/SaleBatchSupplyChainService.java
@@ -20,6 +20,7 @@ package com.axelor.apps.supplychain.service.batch;
 
 import com.axelor.apps.base.AxelorException;
 import com.axelor.apps.base.db.Batch;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.sale.db.SaleBatch;
 import com.axelor.apps.sale.db.repo.SaleBatchRepository;
 import com.axelor.apps.sale.service.batch.SaleBatchService;
@@ -29,13 +30,21 @@ import jakarta.inject.Inject;
 
 public class SaleBatchSupplyChainService extends SaleBatchService {
 
+  protected final AppBaseService appBaseService;
+
   @Inject
-  public SaleBatchSupplyChainService(SaleBatchRepository saleBatchRepo) {
+  public SaleBatchSupplyChainService(
+      SaleBatchRepository saleBatchRepo, AppBaseService appBaseService) {
     super(saleBatchRepo);
+    this.appBaseService = appBaseService;
   }
 
   @Override
   public Batch run(Model batchModel) throws AxelorException {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.run(batchModel);
+    }
+
     SaleBatch saleBatch = (SaleBatch) batchModel;
     switch (saleBatch.getActionSelect()) {
       case SaleBatchRepository.ACTION_INVOICING:

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/cart/CartResetSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/cart/CartResetSupplychainServiceImpl.java
@@ -18,6 +18,7 @@
  */
 package com.axelor.apps.supplychain.service.cart;
 
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.sale.db.Cart;
 import com.axelor.apps.sale.db.repo.CartRepository;
 import com.axelor.apps.sale.service.cart.CartResetServiceImpl;
@@ -26,14 +27,23 @@ import jakarta.inject.Inject;
 
 public class CartResetSupplychainServiceImpl extends CartResetServiceImpl {
 
+  protected final AppBaseService appBaseService;
+
   @Inject
-  public CartResetSupplychainServiceImpl(CartRepository cartRepository) {
+  public CartResetSupplychainServiceImpl(
+      CartRepository cartRepository, AppBaseService appBaseService) {
     super(cartRepository);
+    this.appBaseService = appBaseService;
   }
 
   @Override
   @Transactional(rollbackOn = Exception.class)
   public void emptyCart(Cart cart) {
+    if (!appBaseService.isApp("supplychain")) {
+      super.emptyCart(cart);
+      return;
+    }
+
     cart = cartRepository.find(cart.getId());
     cart.setStockLocation(null);
     super.emptyCart(cart);

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/cart/CartSaleOrderGeneratorSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/cart/CartSaleOrderGeneratorSupplychainServiceImpl.java
@@ -72,6 +72,10 @@ public class CartSaleOrderGeneratorSupplychainServiceImpl
   @Transactional(rollbackOn = Exception.class)
   protected SaleOrder createSaleOrder(Cart cart, List<CartLine> cartLineList)
       throws JsonProcessingException, AxelorException {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.createSaleOrder(cart, cartLineList);
+    }
+
     SaleConfig saleConfig = saleConfigService.getSaleConfig(cart.getCompany());
     int cartOrderCreationModeSelect = saleConfig.getCartOrderCreationModeSelect();
     List<CartLine> availableCartLineList =

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/cartline/CartLineProductSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/cartline/CartLineProductSupplychainServiceImpl.java
@@ -19,6 +19,7 @@
 package com.axelor.apps.supplychain.service.cartline;
 
 import com.axelor.apps.base.AxelorException;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.sale.db.Cart;
 import com.axelor.apps.sale.db.CartLine;
 import com.axelor.apps.sale.service.cartline.CartLinePriceService;
@@ -30,20 +31,28 @@ import java.util.Map;
 public class CartLineProductSupplychainServiceImpl extends CartLineProductServiceImpl {
 
   protected CartLineAvailabilityService cartLineAvailabilityService;
+  protected final AppBaseService appBaseService;
 
   @Inject
   public CartLineProductSupplychainServiceImpl(
       SaleOrderLineProductService saleOrderLineProductService,
       CartLinePriceService cartLinePriceService,
-      CartLineAvailabilityService cartLineAvailabilityService) {
+      CartLineAvailabilityService cartLineAvailabilityService,
+      AppBaseService appBaseService) {
     super(saleOrderLineProductService, cartLinePriceService);
     this.cartLineAvailabilityService = cartLineAvailabilityService;
+    this.appBaseService = appBaseService;
   }
 
   @Override
   public Map<String, Object> getProductInformation(Cart cart, CartLine cartLine)
       throws AxelorException {
     Map<String, Object> cartLineMap = super.getProductInformation(cart, cartLine);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return cartLineMap;
+    }
+
     cartLineMap.putAll(cartLineAvailabilityService.setAvailableStatus(cart, cartLine));
     return cartLineMap;
   }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/invoice/InvoiceLineAnalyticSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/invoice/InvoiceLineAnalyticSupplychainServiceImpl.java
@@ -69,6 +69,11 @@ public class InvoiceLineAnalyticSupplychainServiceImpl extends InvoiceLineAnalyt
   public List<AnalyticMoveLine> createAnalyticDistributionWithTemplate(InvoiceLine invoiceLine) {
     List<AnalyticMoveLine> analyticMoveLineList =
         super.createAnalyticDistributionWithTemplate(invoiceLine);
+
+    if (!appAccountService.isApp("supplychain")) {
+      return analyticMoveLineList;
+    }
+
     for (AnalyticMoveLine analyticMoveLine : analyticMoveLineList) {
       analyticMoveLine.setSaleOrderLine(invoiceLine.getSaleOrderLine());
       analyticMoveLine.setPurchaseOrderLine(invoiceLine.getPurchaseOrderLine());

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/invoice/InvoiceMergingServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/invoice/InvoiceMergingServiceSupplychainImpl.java
@@ -23,6 +23,7 @@ import com.axelor.apps.account.db.repo.InvoiceRepository;
 import com.axelor.apps.account.service.invoice.InvoiceMergingServiceImpl;
 import com.axelor.apps.account.service.invoice.InvoiceService;
 import com.axelor.apps.base.AxelorException;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.purchase.db.PurchaseOrder;
 import com.axelor.apps.sale.db.SaleOrder;
 import com.axelor.apps.supplychain.service.PurchaseOrderInvoiceService;
@@ -35,16 +36,19 @@ public class InvoiceMergingServiceSupplychainImpl extends InvoiceMergingServiceI
 
   protected final PurchaseOrderInvoiceService purchaseOrderInvoiceService;
   protected final SaleOrderInvoiceService saleOrderInvoiceService;
+  protected final AppBaseService appBaseService;
 
   @Inject
   public InvoiceMergingServiceSupplychainImpl(
       InvoiceService invoiceService,
       InvoiceRepository invoiceRepository,
       PurchaseOrderInvoiceService purchaseOrderInvoiceService,
-      SaleOrderInvoiceService saleOrderInvoiceService) {
+      SaleOrderInvoiceService saleOrderInvoiceService,
+      AppBaseService appBaseService) {
     super(invoiceService, invoiceRepository);
     this.purchaseOrderInvoiceService = purchaseOrderInvoiceService;
     this.saleOrderInvoiceService = saleOrderInvoiceService;
+    this.appBaseService = appBaseService;
   }
 
   protected static class CommonFieldsSupplychainImpl extends CommonFieldsImpl {
@@ -119,6 +123,11 @@ public class InvoiceMergingServiceSupplychainImpl extends InvoiceMergingServiceI
   protected void extractFirstNonNullCommonFields(
       List<Invoice> invoicesToMerge, InvoiceMergingResult result) {
     super.extractFirstNonNullCommonFields(invoicesToMerge, result);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return;
+    }
+
     if (result.getInvoiceType().equals(InvoiceRepository.OPERATION_TYPE_CLIENT_SALE)) {
       invoicesToMerge.stream()
           .map(Invoice::getSaleOrder)
@@ -138,6 +147,11 @@ public class InvoiceMergingServiceSupplychainImpl extends InvoiceMergingServiceI
   @Override
   protected void fillCommonFields(Invoice invoice, InvoiceMergingResult result) {
     super.fillCommonFields(invoice, result);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return;
+    }
+
     if (result.getInvoiceType().equals(InvoiceRepository.OPERATION_TYPE_CLIENT_SALE)) {
       if (getCommonFields(result).getCommonSaleOrder() != null
           && !getCommonFields(result).getCommonSaleOrder().equals(invoice.getSaleOrder())) {
@@ -157,6 +171,10 @@ public class InvoiceMergingServiceSupplychainImpl extends InvoiceMergingServiceI
   @Override
   protected Invoice generateMergedInvoice(
       List<Invoice> invoicesToMerge, InvoiceMergingResult result) throws AxelorException {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.generateMergedInvoice(invoicesToMerge, result);
+    }
+
     if (result.getInvoiceType().equals(InvoiceRepository.OPERATION_TYPE_SUPPLIER_PURCHASE)
         || result.getInvoiceType().equals(InvoiceRepository.OPERATION_TYPE_SUPPLIER_REFUND)) {
       return purchaseOrderInvoiceService.mergeInvoice(

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/pricing/PricingGroupSupplyChainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/pricing/PricingGroupSupplyChainServiceImpl.java
@@ -20,6 +20,7 @@ package com.axelor.apps.supplychain.service.pricing;
 
 import com.axelor.apps.base.db.Pricing;
 import com.axelor.apps.base.db.repo.PricingRepository;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.base.service.pricing.PricingGenericService;
 import com.axelor.apps.sale.service.PricingGroupSaleServiceImpl;
 import com.axelor.apps.supplychain.db.FreightCarrierPricing;
@@ -29,14 +30,22 @@ import java.util.stream.Collectors;
 
 public class PricingGroupSupplyChainServiceImpl extends PricingGroupSaleServiceImpl {
 
+  protected final AppBaseService appBaseService;
+
   @Inject
-  public PricingGroupSupplyChainServiceImpl(PricingGenericService pricingGenericService) {
+  public PricingGroupSupplyChainServiceImpl(
+      PricingGenericService pricingGenericService, AppBaseService appBaseService) {
     super(pricingGenericService);
+    this.appBaseService = appBaseService;
   }
 
   @Override
   public String getConcernedModelDomain(Pricing pricing) {
     String domain = super.getConcernedModelDomain(pricing);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return domain;
+    }
 
     if (PricingRepository.PRICING_TYPE_SELECT_FREIGHT_CARRIER_PRICING.equals(
             pricing.getTypeSelect())

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/purchaseorderline/view/PurchaseOrderLineViewServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/purchaseorderline/view/PurchaseOrderLineViewServiceSupplychainImpl.java
@@ -21,10 +21,12 @@ package com.axelor.apps.supplychain.service.purchaseorderline.view;
 import com.axelor.apps.base.db.Company;
 import com.axelor.apps.base.db.Product;
 import com.axelor.apps.base.db.repo.ProductRepository;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.purchase.db.PurchaseOrderLine;
 import com.axelor.apps.purchase.service.purchaseorderline.view.PurchaseOrderLineViewServiceImpl;
 import com.axelor.apps.supplychain.db.SupplyChainConfig;
 import com.axelor.auth.AuthUtils;
+import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -33,8 +35,19 @@ public class PurchaseOrderLineViewServiceSupplychainImpl extends PurchaseOrderLi
 
   private static final String HIDDEN_ATTR = "hidden";
 
+  protected final AppBaseService appBaseService;
+
+  @Inject
+  public PurchaseOrderLineViewServiceSupplychainImpl(AppBaseService appBaseService) {
+    this.appBaseService = appBaseService;
+  }
+
   @Override
   public Map<String, Map<String, Object>> hideDeliveryPanel(PurchaseOrderLine purchaseOrderLine) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.hideDeliveryPanel(purchaseOrderLine);
+    }
+
     Map<String, Map<String, Object>> attrs = new HashMap<>();
     String productTypeSelect =
         Optional.ofNullable(purchaseOrderLine.getProduct())

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderDummySupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderDummySupplychainServiceImpl.java
@@ -50,6 +50,11 @@ public class SaleOrderDummySupplychainServiceImpl extends SaleOrderDummyServiceI
   @Override
   public Map<String, Object> getOnLoadSplitDummies(SaleOrder saleOrder) throws AxelorException {
     Map<String, Object> dummies = super.getOnLoadSplitDummies(saleOrder);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return dummies;
+    }
+
     dummies.putAll(fillIsUsedCreditExceeded(saleOrder));
     return dummies;
   }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderGeneratorSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderGeneratorSupplychainServiceImpl.java
@@ -80,6 +80,11 @@ public class SaleOrderGeneratorSupplychainServiceImpl extends SaleOrderGenerator
     SaleOrder saleOrder =
         super.createSaleOrder(
             clientPartner, deliveredPartner, company, contactPartner, currency, inAti);
+
+    if (!appSaleService.isApp("supplychain")) {
+      return saleOrder;
+    }
+
     setDeliveredPartner(deliveredPartner, clientPartner, saleOrder);
     return saleOrder;
   }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderInitValueSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderInitValueSupplychainServiceImpl.java
@@ -85,6 +85,11 @@ public class SaleOrderInitValueSupplychainServiceImpl extends SaleOrderInitValue
   @Override
   public Map<String, Object> getOnNewInitValues(SaleOrder saleOrder) throws AxelorException {
     Map<String, Object> initValues = super.getOnNewInitValues(saleOrder);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return initValues;
+    }
+
     initValues.putAll(getPaymentMode(saleOrder));
     initValues.putAll(getBankDetails(saleOrder));
     initValues.putAll(saleOrderStockLocationService.getStockLocation(saleOrder));
@@ -98,6 +103,10 @@ public class SaleOrderInitValueSupplychainServiceImpl extends SaleOrderInitValue
   protected Map<String, Object> saleOrderDefaultValuesMap(SaleOrder saleOrder)
       throws AxelorException {
     Map<String, Object> saleOrderMap = super.saleOrderDefaultValuesMap(saleOrder);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return saleOrderMap;
+    }
 
     TradingName tradingName = saleOrder.getTradingName();
     saleOrderMap.put("amountInvoiced", BigDecimal.ZERO);

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderMarginSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderMarginSupplychainServiceImpl.java
@@ -40,6 +40,11 @@ public class SaleOrderMarginSupplychainServiceImpl extends SaleOrderMarginServic
   @Override
   public void computeMarginSaleOrder(SaleOrder saleOrder) {
     super.computeMarginSaleOrder(saleOrder);
+
+    if (!appSaleService.isApp("supplychain")) {
+      return;
+    }
+
     saleOrder.setTotalCostPrice(saleOrder.getTotalCostPrice().add(saleOrder.getShippingCost()));
   }
 }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderVersionSupplyChainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/SaleOrderVersionSupplyChainServiceImpl.java
@@ -50,6 +50,11 @@ public class SaleOrderVersionSupplyChainServiceImpl extends SaleOrderVersionServ
   @Override
   @Transactional(rollbackOn = {Exception.class})
   public void createNewVersion(SaleOrder saleOrder) {
+    if (!appBaseService.isApp("supplychain")) {
+      super.createNewVersion(saleOrder);
+      return;
+    }
+
     saleOrder.setDeliveryState(SaleOrderRepository.DELIVERY_STATE_NOT_DELIVERED);
     saleOrder.setInvoicingState(SaleOrderRepository.INVOICING_STATE_NOT_INVOICED);
     super.createNewVersion(saleOrder);

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/onchange/SaleOrderOnChangeSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/onchange/SaleOrderOnChangeSupplychainServiceImpl.java
@@ -115,6 +115,11 @@ public class SaleOrderOnChangeSupplychainServiceImpl extends SaleOrderOnChangeSe
   @Override
   public Map<String, Object> partnerOnChange(SaleOrder saleOrder) throws AxelorException {
     Map<String, Object> values = super.partnerOnChange(saleOrder);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return values;
+    }
+
     values.putAll(getPaymentCondition(saleOrder));
     values.putAll(getPaymentMode(saleOrder));
     values.putAll(getIncoterm(saleOrder));
@@ -134,6 +139,11 @@ public class SaleOrderOnChangeSupplychainServiceImpl extends SaleOrderOnChangeSe
   @Override
   public Map<String, Object> companyOnChange(SaleOrder saleOrder) throws AxelorException {
     Map<String, Object> values = super.companyOnChange(saleOrder);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return values;
+    }
+
     values.putAll(saleOrderStockLocationService.getStockLocation(saleOrder));
     values.putAll(saleOrderStockLocationService.getToStockLocation(saleOrder));
     values.putAll(getIncoterm(saleOrder));
@@ -164,6 +174,11 @@ public class SaleOrderOnChangeSupplychainServiceImpl extends SaleOrderOnChangeSe
   @Override
   protected Map<String, Object> getClientPartnerValues(SaleOrder saleOrder) {
     Map<String, Object> values = super.getClientPartnerValues(saleOrder);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return values;
+    }
+
     Partner clientPartner = saleOrder.getClientPartner();
     if (clientPartner != null) {
       saleOrder.setIsNeedingConformityCertificate(
@@ -220,6 +235,10 @@ public class SaleOrderOnChangeSupplychainServiceImpl extends SaleOrderOnChangeSe
 
   @Override
   protected Map<String, Object> getFiscalPosition(SaleOrder saleOrder) {
+    if (!appBaseService.isApp("supplychain")) {
+      return super.getFiscalPosition(saleOrder);
+    }
+
     Map<String, Object> values = new HashMap<>();
     AppBase appBase = appBaseService.getAppBase();
     if (!appBase.getActivatePartnerRelations()) {
@@ -305,6 +324,11 @@ public class SaleOrderOnChangeSupplychainServiceImpl extends SaleOrderOnChangeSe
   @Override
   protected Map<String, Object> getComputeSaleOrderMap(SaleOrder saleOrder) throws AxelorException {
     Map<String, Object> values = super.getComputeSaleOrderMap(saleOrder);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return values;
+    }
+
     values.put("standardDelay", saleOrder.getStandardDelay());
     values.put("amountToBeSpreadOverTheTimetable", saleOrder.getAmountToBeSpreadOverTheTimetable());
 

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/onchange/SaleOrderOnLineChangeSupplyChainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/onchange/SaleOrderOnLineChangeSupplyChainServiceImpl.java
@@ -81,6 +81,10 @@ public class SaleOrderOnLineChangeSupplyChainServiceImpl extends SaleOrderOnLine
 
   @Override
   public String onLineChange(SaleOrder saleOrder) throws AxelorException {
+    if (!appSaleService.isApp("supplychain")) {
+      return super.onLineChange(saleOrder);
+    }
+
     super.onLineChange(saleOrder);
     List<String> messages = new ArrayList<>();
     saleOrderSupplychainService.setAdvancePayment(saleOrder);

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/opportunity/OpportunitySaleOrderSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorder/opportunity/OpportunitySaleOrderSupplychainServiceImpl.java
@@ -51,6 +51,10 @@ public class OpportunitySaleOrderSupplychainServiceImpl extends OpportunitySaleO
   public SaleOrder createSaleOrderFromOpportunity(Opportunity opportunity) throws AxelorException {
     SaleOrder saleOrder = super.createSaleOrderFromOpportunity(opportunity);
 
+    if (!appBaseService.isApp("supplychain")) {
+      return saleOrder;
+    }
+
     // Adding supplychain behaviour
     // Set default invoiced and delivered partners and address in case of partner delegations
     if (appBaseService.getAppBase().getActivatePartnerRelations()) {

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineCreateSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineCreateSupplychainServiceImpl.java
@@ -69,6 +69,10 @@ public class SaleOrderLineCreateSupplychainServiceImpl extends SaleOrderLineCrea
     SaleOrderLine soLine =
         super.createSaleOrderLine(packLine, saleOrder, packQty, conversionRate, sequence);
 
+    if (!appBaseService.isApp("supplychain")) {
+      return soLine;
+    }
+
     if (soLine != null && soLine.getProduct() != null) {
       soLine.setSaleSupplySelect(soLine.getProduct().getSaleSupplySelect());
 

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineInitValueSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineInitValueSupplychainServiceImpl.java
@@ -54,6 +54,11 @@ public class SaleOrderLineInitValueSupplychainServiceImpl
       SaleOrder saleOrder, SaleOrderLine saleOrderLine, SaleOrderLine parentSol)
       throws AxelorException {
     Map<String, Object> values = super.onNewInitValues(saleOrder, saleOrderLine, parentSol);
+
+    if (!appSupplychainService.isApp("supplychain")) {
+      return values;
+    }
+
     AppSupplychain appSupplychain = appSupplychainService.getAppSupplychain();
     if (appSupplychain.getManageStockReservation()) {
       values.putAll(saleOrderLineServiceSupplyChain.updateRequestedReservedQty(saleOrderLine));
@@ -67,6 +72,11 @@ public class SaleOrderLineInitValueSupplychainServiceImpl
   public Map<String, Object> onLoadInitValues(SaleOrder saleOrder, SaleOrderLine saleOrderLine)
       throws AxelorException {
     Map<String, Object> values = super.onLoadInitValues(saleOrder, saleOrderLine);
+
+    if (!appSupplychainService.isApp("supplychain")) {
+      return values;
+    }
+
     values.putAll(saleOrderLineAnalyticService.printAnalyticAccounts(saleOrder, saleOrderLine));
     return values;
   }
@@ -75,6 +85,11 @@ public class SaleOrderLineInitValueSupplychainServiceImpl
   public Map<String, Object> onNewEditableInitValues(
       SaleOrder saleOrder, SaleOrderLine saleOrderLine, SaleOrderLine parentSol) {
     Map<String, Object> values = super.onNewEditableInitValues(saleOrder, saleOrderLine, parentSol);
+
+    if (!appSupplychainService.isApp("supplychain")) {
+      return values;
+    }
+
     values.putAll(fillRequestQty(saleOrder, saleOrderLine));
     return values;
   }

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineOnChangeSupplychainServiceImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineOnChangeSupplychainServiceImpl.java
@@ -70,6 +70,10 @@ public class SaleOrderLineOnChangeSupplychainServiceImpl extends SaleOrderLineOn
   public Map<String, Object> qtyOnChange(
       SaleOrderLine saleOrderLine, SaleOrder saleOrder, SaleOrderLine parentSol)
       throws AxelorException {
+    if (!appSupplychainService.isApp("supplychain")) {
+      return super.qtyOnChange(saleOrderLine, saleOrder, parentSol);
+    }
+
     AppSupplychain appSupplychain = appSupplychainService.getAppSupplychain();
     Map<String, Object> saleOrderLineMap = super.qtyOnChange(saleOrderLine, saleOrder, parentSol);
     if (appSupplychain.getManageStockReservation()) {
@@ -85,6 +89,11 @@ public class SaleOrderLineOnChangeSupplychainServiceImpl extends SaleOrderLineOn
   public Map<String, Object> compute(SaleOrderLine saleOrderLine, SaleOrder saleOrder)
       throws AxelorException {
     Map<String, Object> saleOrderLineMap = super.compute(saleOrderLine, saleOrder);
+
+    if (!appSupplychainService.isApp("supplychain")) {
+      return saleOrderLineMap;
+    }
+
     saleOrderLineMap.putAll(computeAnalyticDistribution(saleOrderLine, saleOrder));
 
     return saleOrderLineMap;

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineViewServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/saleorderline/SaleOrderLineViewServiceSupplychainImpl.java
@@ -65,6 +65,11 @@ public class SaleOrderLineViewServiceSupplychainImpl extends SaleOrderLineViewSe
       SaleOrderLine saleOrderLine, SaleOrder saleOrder) throws AxelorException {
     Map<String, Map<String, Object>> attrs =
         super.getProductOnChangeAttrs(saleOrderLine, saleOrder);
+
+    if (!appBaseService.isApp("supplychain")) {
+      return attrs;
+    }
+
     MapTools.addMap(attrs, hideDeliveryPanel(saleOrderLine));
     analyticAttrsService.addAnalyticAxisAttrs(saleOrder.getCompany(), null, attrs);
     MapTools.addMap(

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/workflow/WorkflowCancelServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/workflow/WorkflowCancelServiceSupplychainImpl.java
@@ -24,6 +24,7 @@ import com.axelor.apps.account.db.repo.InvoiceRepository;
 import com.axelor.apps.account.service.invoice.InvoiceToolService;
 import com.axelor.apps.account.service.invoice.workflow.cancel.WorkflowCancelServiceImpl;
 import com.axelor.apps.base.AxelorException;
+import com.axelor.apps.base.service.app.AppBaseService;
 import com.axelor.apps.purchase.db.PurchaseOrder;
 import com.axelor.apps.purchase.db.PurchaseOrderLine;
 import com.axelor.apps.purchase.db.repo.PurchaseOrderRepository;
@@ -59,6 +60,8 @@ public class WorkflowCancelServiceSupplychainImpl extends WorkflowCancelServiceI
 
   protected TimetableService timetableService;
 
+  protected AppBaseService appBaseService;
+
   @Inject
   public WorkflowCancelServiceSupplychainImpl(
       SaleOrderInvoiceService saleOrderInvoiceService,
@@ -66,7 +69,8 @@ public class WorkflowCancelServiceSupplychainImpl extends WorkflowCancelServiceI
       SaleOrderRepository saleOrderRepository,
       PurchaseOrderRepository purchaseOrderRepository,
       SaleInvoicingStateService saleInvoicingStateService,
-      TimetableService timetableService) {
+      TimetableService timetableService,
+      AppBaseService appBaseService) {
 
     this.saleOrderInvoiceService = saleOrderInvoiceService;
     this.purchaseOrderInvoiceService = purchaseOrderInvoiceService;
@@ -74,6 +78,7 @@ public class WorkflowCancelServiceSupplychainImpl extends WorkflowCancelServiceI
     this.purchaseOrderRepository = purchaseOrderRepository;
     this.saleInvoicingStateService = saleInvoicingStateService;
     this.timetableService = timetableService;
+    this.appBaseService = appBaseService;
   }
 
   private PurchaseOrderRepository purchaseOrderRepository;
@@ -85,6 +90,11 @@ public class WorkflowCancelServiceSupplychainImpl extends WorkflowCancelServiceI
 
   @Override
   public void afterCancel(Invoice invoice) throws AxelorException {
+    if (!appBaseService.isApp("supplychain")) {
+      super.afterCancel(invoice);
+      return;
+    }
+
     timetableService.cancelTimetable(invoice);
     if (oldInvoiceStatusSelect == InvoiceRepository.STATUS_VENTILATED) {
 

--- a/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/workflow/WorkflowVentilationServiceSupplychainImpl.java
+++ b/axelor-supplychain/src/main/java/com/axelor/apps/supplychain/service/workflow/WorkflowVentilationServiceSupplychainImpl.java
@@ -135,6 +135,11 @@ public class WorkflowVentilationServiceSupplychainImpl extends WorkflowVentilati
 
   public void afterVentilation(Invoice invoice) throws AxelorException {
     super.afterVentilation(invoice);
+
+    if (!appSupplychainService.isApp("supplychain")) {
+      return;
+    }
+
     if (InvoiceToolService.isPurchase(invoice)) {
 
       // Update amount invoiced on PurchaseOrder

--- a/axelor-supplychain/src/test/java/com/axelor/apps/supplychain/service/TestPurchaseOrderLineTaxService.java
+++ b/axelor-supplychain/src/test/java/com/axelor/apps/supplychain/service/TestPurchaseOrderLineTaxService.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.axelor.apps.account.db.Tax;
 import com.axelor.apps.account.db.TaxEquiv;
@@ -54,6 +55,7 @@ class TestPurchaseOrderLineTaxService {
   void setUp() {
     orderLineTaxService = mock(OrderLineTaxService.class);
     appBaseService = mock(AppBaseService.class);
+    when(appBaseService.isApp("supplychain")).thenReturn(true);
     purchaseOrderLineTaxService = createPurchaseOrderLineTaxService(mock(TaxService.class));
   }
 
@@ -240,7 +242,8 @@ class TestPurchaseOrderLineTaxService {
         orderLineTaxService,
         taxService,
         appBaseService,
-        new PurchaseOrderLineTaxComputeSupplychainServiceImp(new CurrencyScaleServiceImpl()));
+        new PurchaseOrderLineTaxComputeSupplychainServiceImp(
+            new CurrencyScaleServiceImpl(), appBaseService));
   }
 
   protected PurchaseOrder createPurchaseOrder(PurchaseOrderLine... purchaseOrderLines) {

--- a/changelogs/unreleased/117724.yml
+++ b/changelogs/unreleased/117724.yml
@@ -39,5 +39,7 @@ developer: |
   - `com.axelor.apps.supplychain.service.StockMoveCurrencyServiceSupplychainImpl`
 
   `SaleOrderSupplychainRepository` and `LogisticalFormSupplychainRepository` take the service
-  through their existing constructor, which breaks their subclasses too. The repositories
-  that have no constructor read the check from a new injected `appBaseService` field.
+  through their existing constructor, which breaks their subclasses too. The four
+  repositories that have no constructor read the check through
+  `Beans.get(AppBaseService.class)`, the way they already fetch their other collaborators, so
+  they gain neither a field nor a constructor.

--- a/changelogs/unreleased/117724.yml
+++ b/changelogs/unreleased/117724.yml
@@ -1,0 +1,40 @@
+---
+title: "App check: axelor-supplychain no longer changes the behaviour of the modules it extends when the Supply Chain app is not installed."
+module: axelor-supplychain
+developer: |
+  The 53 remaining cross-module overrides of `axelor-supplychain` now guard their
+  supplychain specific behaviour on `isApp("supplychain")` and delegate to `super` when the
+  app is off. The check is done with the app service already injected in the class when
+  there is one (`AppSupplychainService`, `AppBaseService`, `AppAccountService`,
+  `AppSaleService`, `AppPurchaseService`), otherwise `AppBaseService` is injected.
+
+  Five classes needed no guard and are now listed in
+  `config/app-override-guard-allowlist.txt` as justified exceptions: they are bound in place
+  of a class of a lower module but override none of its methods, they only add the methods of
+  their own supplychain interface (`AdvancePaymentServiceSupplychainImpl`,
+  `StockLocationUtilsServiceSupplychainImpl`, `AccountingCutOffSupplyChainServiceImpl`,
+  `PartnerSupplychainServiceImpl`, `PartnerLinkSupplychainServiceImpl`).
+
+  The following classes get a new constructor parameter, which breaks subclasses calling
+  their constructor:
+
+  - `com.axelor.apps.supplychain.service.workflow.WorkflowCancelServiceSupplychainImpl`
+  - `com.axelor.apps.supplychain.service.StockHistoryServiceSupplyChainImpl`
+  - `com.axelor.apps.supplychain.service.invoice.InvoiceMergingServiceSupplychainImpl`
+  - `com.axelor.apps.supplychain.service.batch.SaleBatchSupplyChainService`
+  - `com.axelor.apps.supplychain.service.cartline.CartLineProductSupplychainServiceImpl`
+  - `com.axelor.apps.supplychain.service.cart.CartResetSupplychainServiceImpl`
+  - `com.axelor.apps.supplychain.service.ConfiguratorCheckServiceSupplychainImpl`
+  - `com.axelor.apps.supplychain.service.TrackingNumberCompanySupplychainServiceImpl`
+  - `com.axelor.apps.supplychain.service.pricing.PricingGroupSupplyChainServiceImpl`
+  - `com.axelor.apps.supplychain.service.analytic.AnalyticMoveLineParentSupplychainServiceImpl`
+  - `com.axelor.apps.supplychain.service.PurchaseOrderLineTaxComputeSupplychainServiceImp`
+
+  These ones had no constructor and now have one, which breaks subclasses too:
+
+  - `com.axelor.apps.supplychain.service.purchaseorderline.view.PurchaseOrderLineViewServiceSupplychainImpl`
+  - `com.axelor.apps.supplychain.rest.StockProductRestServiceSupplychainImpl`
+  - `com.axelor.apps.supplychain.service.StockMoveCurrencyServiceSupplychainImpl`
+
+  The repositories of the module read the check from a new injected `appBaseService` field,
+  so their constructor is unchanged.

--- a/changelogs/unreleased/117724.yml
+++ b/changelogs/unreleased/117724.yml
@@ -29,6 +29,8 @@ developer: |
   - `com.axelor.apps.supplychain.service.pricing.PricingGroupSupplyChainServiceImpl`
   - `com.axelor.apps.supplychain.service.analytic.AnalyticMoveLineParentSupplychainServiceImpl`
   - `com.axelor.apps.supplychain.service.PurchaseOrderLineTaxComputeSupplychainServiceImp`
+  - `com.axelor.apps.supplychain.db.repo.SaleOrderSupplychainRepository`
+  - `com.axelor.apps.supplychain.db.repo.LogisticalFormSupplychainRepository`
 
   These ones had no constructor and now have one, which breaks subclasses too:
 
@@ -36,5 +38,6 @@ developer: |
   - `com.axelor.apps.supplychain.rest.StockProductRestServiceSupplychainImpl`
   - `com.axelor.apps.supplychain.service.StockMoveCurrencyServiceSupplychainImpl`
 
-  The repositories of the module read the check from a new injected `appBaseService` field,
-  so their constructor is unchanged.
+  `SaleOrderSupplychainRepository` and `LogisticalFormSupplychainRepository` take the service
+  through their existing constructor, which breaks their subclasses too. The repositories
+  that have no constructor read the check from a new injected `appBaseService` field.

--- a/config/app-override-guard-allowlist.txt
+++ b/config/app-override-guard-allowlist.txt
@@ -17,7 +17,7 @@
 #      job of the sweep tickets listed below, one module at a time. Do NOT add new entries
 #      to those sections.
 #
-# Sweep tickets: #117724 supplychain, #117725 production, #117726 bank-payment,
+# Sweep tickets: #117725 production, #117726 bank-payment,
 # #117727 human-resource, #117728 maintenance, #117729 contract/intervention/cash-management,
 # #117730 sale/crm/account/stock/talent, #117731 budget.
 #
@@ -179,61 +179,17 @@ com.axelor.apps.stock.db.repo.ProductStockRepository  # overrides ProductBaseRep
 com.axelor.apps.stock.db.repo.ProductCompanyStockRepository  # overrides ProductCompanyBaseRepository (axelor-base)
 
 # ---------------------------------------------------------------------------
-# KNOWN DEBT - axelor-supplychain (53) - to be emptied by #117724
+# JUSTIFIED EXCEPTIONS - axelor-supplychain (5)
 # ---------------------------------------------------------------------------
-com.axelor.apps.supplychain.service.purchaseorderline.view.PurchaseOrderLineViewServiceSupplychainImpl  # overrides PurchaseOrderLineViewServiceImpl (axelor-purchase)
-com.axelor.apps.supplychain.db.repo.SaleOrderSupplychainRepository  # overrides SaleOrderManagementRepository (axelor-sale)
-com.axelor.apps.supplychain.service.saleorderline.SaleOrderLineCreateSupplychainServiceImpl  # overrides SaleOrderLineCreateServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.AdvancePaymentServiceSupplychainImpl  # overrides AdvancePaymentServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.db.repo.AnalyticMoveLineSupplychainRepository  # overrides AnalyticMoveLineMngtRepository (axelor-account)
-com.axelor.apps.supplychain.service.workflow.WorkflowVentilationServiceSupplychainImpl  # overrides WorkflowVentilationServiceImpl (axelor-account)
-com.axelor.apps.supplychain.service.workflow.WorkflowCancelServiceSupplychainImpl  # overrides WorkflowCancelServiceImpl (axelor-account)
-com.axelor.apps.supplychain.utils.StockLocationUtilsServiceSupplychainImpl  # overrides StockLocationUtilsServiceImpl (axelor-stock)
-com.axelor.apps.supplychain.service.AccountingCutOffSupplyChainServiceImpl  # overrides AccountingCutOffServiceImpl (axelor-account)
-com.axelor.apps.supplychain.db.repo.StockMoveSupplychainRepository  # overrides StockMoveManagementRepository (axelor-stock)
-com.axelor.apps.supplychain.service.StockCorrectionServiceSupplychainImpl  # overrides StockCorrectionServiceImpl (axelor-stock)
-com.axelor.apps.supplychain.db.repo.SaleOrderLineSupplychainRepository  # overrides SaleOrderLineSaleRepository (axelor-sale)
-com.axelor.apps.supplychain.db.repo.StockMoveLineSupplychainRepository  # overrides StockMoveLineStockRepository (axelor-stock)
-com.axelor.apps.supplychain.service.PurchaseOrderCreateServiceSupplychainImpl  # overrides PurchaseOrderCreateServiceImpl (axelor-purchase)
-com.axelor.apps.supplychain.service.saleorder.opportunity.OpportunitySaleOrderSupplychainServiceImpl  # overrides OpportunitySaleOrderServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.PartnerSupplychainServiceImpl  # overrides PartnerSaleServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.StockHistoryServiceSupplyChainImpl  # overrides StockHistoryServiceImpl (axelor-stock)
-com.axelor.apps.supplychain.service.invoice.InvoiceMergingServiceSupplychainImpl  # overrides InvoiceMergingServiceImpl (axelor-account)
-com.axelor.apps.supplychain.service.batch.BatchAccountingCutOffSupplyChain  # overrides BatchAccountingCutOff (axelor-account)
-com.axelor.apps.supplychain.rest.StockProductRestServiceSupplychainImpl  # overrides StockProductRestServiceImpl (axelor-stock)
-com.axelor.apps.supplychain.service.AnalyticMoveLineSupplychainServiceImpl  # overrides AnalyticMoveLineServiceImpl (axelor-account)
-com.axelor.apps.supplychain.service.invoice.InvoiceLineAnalyticSupplychainServiceImpl  # overrides InvoiceLineAnalyticServiceImpl (axelor-account)
-com.axelor.apps.supplychain.service.saleorder.SaleOrderVersionSupplyChainServiceImpl  # overrides SaleOrderVersionServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.PartnerLinkSupplychainServiceImpl  # overrides PartnerLinkServiceImpl (axelor-base)
-com.axelor.apps.supplychain.service.saleorder.onchange.SaleOrderOnLineChangeSupplyChainServiceImpl  # overrides SaleOrderOnLineChangeServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.PurchaseOrderMergingServiceSupplyChainImpl  # overrides PurchaseOrderMergingServiceImpl (axelor-purchase)
-com.axelor.apps.supplychain.service.PurchaseOrderMergingViewServiceSupplyChainImpl  # overrides PurchaseOrderMergingViewServiceImpl (axelor-purchase)
-com.axelor.apps.supplychain.service.StockMoveMergingServiceSupplychainImpl  # overrides StockMoveMergingServiceImpl (axelor-stock)
-com.axelor.apps.supplychain.service.saleorderline.SaleOrderLineOnChangeSupplychainServiceImpl  # overrides SaleOrderLineOnChangeServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.saleorder.SaleOrderInitValueSupplychainServiceImpl  # overrides SaleOrderInitValueServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.saleorder.onchange.SaleOrderOnChangeSupplychainServiceImpl  # overrides SaleOrderOnChangeServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.StockMoveLineStockLocationServiceSupplychainImpl  # overrides StockMoveLineStockLocationServiceImpl (axelor-stock)
-com.axelor.apps.supplychain.service.saleorderline.SaleOrderLineViewServiceSupplychainImpl  # overrides SaleOrderLineViewServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.saleorderline.SaleOrderLineInitValueSupplychainServiceImpl  # overrides SaleOrderLineInitValueServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.batch.SaleBatchSupplyChainService  # overrides SaleBatchService (axelor-sale)
-com.axelor.apps.supplychain.db.repo.CartLineSupplychainRepository  # overrides CartLineManagementRepository (axelor-sale)
-com.axelor.apps.supplychain.service.cart.CartSaleOrderGeneratorSupplychainServiceImpl  # overrides CartSaleOrderGeneratorServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.cartline.CartLineProductSupplychainServiceImpl  # overrides CartLineProductServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.cart.CartResetSupplychainServiceImpl  # overrides CartResetServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.ConfiguratorCheckServiceSupplychainImpl  # overrides ConfiguratorCheckServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.TrackingNumberCompanySupplychainServiceImpl  # overrides TrackingNumberCompanyServiceImpl (axelor-stock)
-com.axelor.apps.supplychain.service.PurchaseOrderLineTaxComputeSupplychainServiceImp  # overrides PurchaseOrderLineTaxComputeServiceImpl (axelor-purchase)
-com.axelor.apps.supplychain.service.pricing.PricingGroupSupplyChainServiceImpl  # overrides PricingGroupSaleServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.saleorder.SaleOrderDummySupplychainServiceImpl  # overrides SaleOrderDummyServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.analytic.AnalyticMoveLineParentSupplychainServiceImpl  # overrides AnalyticMoveLineParentServiceImpl (axelor-account)
-com.axelor.apps.supplychain.service.saleorder.SaleOrderGeneratorSupplychainServiceImpl  # overrides SaleOrderGeneratorServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.rest.PartnerCreationServiceSupplychainImpl  # overrides PartnerCreationServiceImpl (axelor-base)
-com.axelor.apps.supplychain.service.CallTenderPurchaseOrderSupplychainServiceImpl  # overrides CallTenderPurchaseOrderServiceImpl (axelor-purchase)
-com.axelor.apps.supplychain.db.repo.LogisticalFormSupplychainRepository  # overrides LogisticalFormStockRepository (axelor-stock)
-com.axelor.apps.supplychain.service.saleorder.SaleOrderMarginSupplychainServiceImpl  # overrides SaleOrderMarginServiceImpl (axelor-sale)
-com.axelor.apps.supplychain.service.LogisticalFormCreateServiceSupplychainImpl  # overrides LogisticalFormCreateServiceImpl (axelor-stock)
-com.axelor.apps.supplychain.service.StockMoveCurrencyServiceSupplychainImpl  # overrides StockMoveCurrencyServiceImpl (axelor-stock)
-com.axelor.apps.supplychain.service.ProductSupplychainServiceImpl  # overrides ProductServicePurchaseImpl (axelor-purchase)
+# The overrides of the supplychain module were guarded by #117724. The classes below are
+# bound in place of a class of a lower module but override none of its methods: they only
+# add the methods of their own supplychain interface, so the behaviour of the overridden
+# module is untouched when the supplychain app is off.
+com.axelor.apps.supplychain.service.AdvancePaymentServiceSupplychainImpl  # bound on AdvancePaymentService (axelor-sale), overrides no method of AdvancePaymentServiceImpl: only adds the advance payment move methods, called from AdvancePaymentSupplychainRepository which already guards on isApp
+com.axelor.apps.supplychain.utils.StockLocationUtilsServiceSupplychainImpl  # bound on StockLocationUtilsService (axelor-stock), overrides no method of StockLocationUtilsServiceImpl: only adds getReservedQtyOfProductInStockLocations of StockLocationUtilsServiceSupplychain
+com.axelor.apps.supplychain.service.AccountingCutOffSupplyChainServiceImpl  # bound on AccountingCutOffService (axelor-account), overrides no method of AccountingCutOffServiceImpl: only adds the stock move cut off methods of AccountingCutOffSupplyChainService
+com.axelor.apps.supplychain.service.PartnerSupplychainServiceImpl  # bound on PartnerSaleService (axelor-sale), overrides no method of PartnerSaleServiceImpl: only adds updateBlockedAccount and isBlockedPartnerOrParent of PartnerSupplychainService
+com.axelor.apps.supplychain.service.PartnerLinkSupplychainServiceImpl  # bound on PartnerLinkService (axelor-base), overrides no method of PartnerLinkServiceImpl: only adds getDefaultInvoicedPartner and getDefaultDeliveredPartner of PartnerLinkSupplychainService
 
 # ---------------------------------------------------------------------------
 # KNOWN DEBT - axelor-talent (1) - to be emptied by #117730


### PR DESCRIPTION
Redmine: https://redmine.axelor.com/issues/117724 (child of #117722, sweep of the `axelor-supplychain` overrides)

## Why

A Guice binding is active as soon as the module is deployed, whatever the state of its app. `axelor-supplychain` has the largest override surface of the suite: it overrides `axelor-sale`, `axelor-purchase`, `axelor-stock`, `axelor-account` and `axelor-base`. 36 of those overrides already guarded on `isApp("supplychain")`, which made the 53 remaining ones inconsistent rather than deliberate: deploying the module changed the behaviour of the modules it sits on top of even with the Supply Chain app off.

This PR empties the `KNOWN DEBT - axelor-supplychain` section of `config/app-override-guard-allowlist.txt` introduced by #117723, so `checkAppOverrideGuard` is now blocking for this module.

## What changed

For each of the 53 classes, only the methods that actually **override a method of the parent** are guarded. Methods that merely add the API of the class's own supplychain interface change nothing for the overridden module and are left alone — that distinction is what decides between a guard and an allowlist entry below.

- **48 classes guarded**, 73 guards, all of the same shape: guard on `isApp("supplychain")` and delegate to `super`, either as an early return or right after the `super` call when the override only enriches its result.
- **App service used for the check**: the one already injected in the class when there is one, own field or inherited `protected` field — `appSupplychainService`, `appBaseService`, `appAccountService`, `appSaleService`, `appPurchaseService`. Otherwise `AppBaseService` comes in by constructor whenever the class already has one, services and repositories alike. The four repositories that have no constructor read it with `Beans.get(AppBaseService.class)` at the call site, the way they already fetch every other collaborator in those same methods. No `@Inject` field was added: field injection is the one form that gives none of the guarantees of constructor injection while still adding state, it silently stays null on any path that builds the repository outside Guice (`JpaRepository.of` has to call `Beans.inject(new JpaRepository<>(type))` for exactly that reason), and it would turn a private need into a `protected` field inherited by the production repositories. Giving those four a constructor was the other option, and it would have forced one into `StockMoveProductionRepository` and `StockMoveLineProductionRepository`, which have none either.
- **5 classes allowlisted as justified exceptions**, with the reason on each line. They are bound in place of a class of a lower module but override none of its methods: `AdvancePaymentServiceSupplychainImpl` (only adds the advance payment move methods, called from `AdvancePaymentSupplychainRepository` which already guards), `StockLocationUtilsServiceSupplychainImpl`, `AccountingCutOffSupplyChainServiceImpl`, `PartnerSupplychainServiceImpl`, `PartnerLinkSupplychainServiceImpl`.
- **#117724 removed from the sweep ticket list** in the allowlist header.

## Breaking for subclasses

14 services and 2 repositories get a new constructor parameter, 3 of the services gaining a constructor they did not have (`PurchaseOrderLineViewServiceSupplychainImpl`, `StockProductRestServiceSupplychainImpl`, `StockMoveCurrencyServiceSupplychainImpl`). The 6 subclasses in the repository are updated in this PR: `WorkflowCancelServiceContractImpl`, `PricingGroupContractServiceImpl`, `AnalyticMoveLineParentContractServiceImpl` (axelor-contract), `TrackingNumberCompanyProductionServiceImpl`, `ConfiguratorCheckServiceProductionImpl` (axelor-production), `SaleOrderBudgetRepository` (axelor-budget). The changelog lists every changed signature for projects overriding them.

## Validation

Full CI-equivalent preflight green on Java 21: `spotlessCheck`, `checkCsvEOL`, `checkBirtCredentials`, `checkJavaInjectAnnotationImport`, `checkXml`, `generateChangelog`, `-xtest clean build`, full `test`.

- `checkAppOverrideGuard` passes, rerun with `--rerun-tasks`.
- `compileJava` green on every module, so no caller of the changed constructors was missed.
- `axelor-supplychain`, `axelor-production`, `axelor-contract` and `axelor-budget` test suites green. `TestPurchaseOrderLineTaxService` builds `PurchaseOrderLineTaxComputeSupplychainServiceImp` directly and now stubs `isApp("supplychain")` to `true` on its existing `AppBaseService` mock.

## Notes

- No functional change and no refactoring of the overridden logic: with the app on, every guarded method keeps its exact previous behaviour.
- The covariant overrides of the merging services (`create`, `getCommonFields`, `getChecks` in `InvoiceMergingServiceSupplychainImpl` and `PurchaseOrderMergingServiceSupplyChainImpl`) are left unguarded on purpose: they only widen the returned result type, the behaviour lives in the sibling methods, which are guarded.
- `checkAppOverrideGuard` only looks for a single `isApp(` occurrence per class, so it cannot confirm that every override of these 48 classes is guarded — that part stays a review job, method by method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
